### PR TITLE
Fix #4: NPC body fails to despawn after being attacked

### DIFF
--- a/src/main/java/ragamuffin/core/InteractionSystem.java
+++ b/src/main/java/ragamuffin/core/InteractionSystem.java
@@ -304,6 +304,9 @@ public class InteractionSystem {
         float closestDistance = INTERACTION_RANGE;
 
         for (NPC npc : npcs) {
+            // Dead NPCs cannot be interacted with
+            if (!npc.isAlive()) continue;
+
             // Check if NPC is within interaction range
             float distance = playerPos.dst(npc.getPosition());
             if (distance <= INTERACTION_RANGE) {

--- a/src/main/java/ragamuffin/core/RagamuffinGame.java
+++ b/src/main/java/ragamuffin/core/RagamuffinGame.java
@@ -1144,6 +1144,9 @@ public class RagamuffinGame extends ApplicationAdapter {
             blockHit.getBlockY() + 0.5f, blockHit.getBlockZ() + 0.5f) : reach;
 
         for (NPC npc : npcManager.getNPCs()) {
+            // Dead NPCs cannot be punched
+            if (!npc.isAlive()) continue;
+
             // Calculate distance to NPC centre (at chest height)
             float npcCentreY = npc.getPosition().y + NPC.HEIGHT * 0.5f;
             float dx = npc.getPosition().x - cameraPos.x;


### PR DESCRIPTION
## Summary
Automated fix for issue #4.

## Changes
Issue #4 is fixed. Here's a summary of what was done:

## Fix #4: NPC body fails to despawn / unlimited item exploit

**Root cause**: Two targeting functions failed to filter out dead NPCs, allowing a player to interact with or punch a corpse during the 2-second window before it despawns.

**Fixes:**

1. **`InteractionSystem.java` — `findNPCInRange`**: Added `if (!npc.isAlive()) continue;` so dead NPCs are invisible to the E-key interaction system. This prevents the corpse from being interacted with for unlimited chips/sausage rolls.

2. **`RagamuffinGame.java` — `findNPCInReach`**: Added `if (!npc.isAlive()) continue;` so dead NPCs cannot be punched for additional loot drops.

The NPCManager's despawn logic (removes NPC once death speech expires after ~2 seconds) was already correct — the body does eventually despawn. The bug was that during that brief window, both interaction and punching still targeted the corpse.

**Tests added** (in `NPCLootDropIntegrationTest.java`):
- `test9_Dea

Closes #4