### PR TITLE
Fix #36: HealingSystem.update() multiplies threshold by delta, making resting check always false — player never heals

### DIFF
--- a/src/main/java/ragamuffin/core/HealingSystem.java
+++ b/src/main/java/ragamuffin/core/HealingSystem.java
@@ -30,7 +30,7 @@ public class HealingSystem {
         Vector3 currentPos = player.getPosition();
         float distanceMoved = currentPos.dst(lastPosition);
 
-        if (distanceMoved < MOVEMENT_THRESHOLD * delta) {
+        if (distanceMoved < MOVEMENT_THRESHOLD) {
             // Player is resting
             restingTime += delta;
         } else {


### PR DESCRIPTION
## Summary
Automated fix for issue #36.

## Changes
- Fix #36: remove * delta from MOVEMENT_THRESHOLD comparison in HealingSystem

Closes #36