### PR TITLE
Fix #40: BlockBreaker: stale hit counter after NPC demolition causes blocks to break in too few hits

### DIFF
--- a/src/main/java/ragamuffin/ai/NPCManager.java
+++ b/src/main/java/ragamuffin/ai/NPCManager.java
@@ -1,6 +1,7 @@
 package ragamuffin.ai;
 
 import com.badlogic.gdx.math.Vector3;
+import ragamuffin.building.BlockBreaker;
 import ragamuffin.building.Inventory;
 import ragamuffin.building.Material;
 import ragamuffin.building.StructureTracker;
@@ -128,6 +129,9 @@ public class NPCManager {
 
     // Per-NPC structure scan stagger — spread checks over time
     private Map<NPC, Float> npcStructureCheckTimers;
+
+    // BlockBreaker reference — used to clear stale hit counters when demolishing blocks
+    private BlockBreaker blockBreaker;
 
     // Arrest system — set when police catches player so game loop can apply penalties
     private boolean arrestPending = false;
@@ -1715,6 +1719,12 @@ public class NPCManager {
         structure.removeBlock(blockToRemove);
         structureTracker.removeBlock(x, y, z);
 
+        // Clear any stale hit counter so a newly-placed block at this position
+        // starts fresh and requires the full number of hits to break.
+        if (blockBreaker != null) {
+            blockBreaker.clearHits(x, y, z);
+        }
+
         // Remove planning notice if present
         world.removePlanningNotice(x, y, z);
 
@@ -1735,6 +1745,13 @@ public class NPCManager {
         // Set knockback timer (delays demolition for 1 second)
         builderKnockbackTimers.put(builder, 1.0f);
         builder.setState(NPCState.KNOCKED_BACK);
+    }
+
+    /**
+     * Set the BlockBreaker so demolishBlock() can clear stale hit counters.
+     */
+    public void setBlockBreaker(BlockBreaker blockBreaker) {
+        this.blockBreaker = blockBreaker;
     }
 
     /**

--- a/src/main/java/ragamuffin/building/BlockBreaker.java
+++ b/src/main/java/ragamuffin/building/BlockBreaker.java
@@ -108,6 +108,15 @@ public class BlockBreaker {
     }
 
     /**
+     * Clear the hit counter for a specific block position.
+     * Call this when a block is removed externally (e.g. by an NPC) so stale
+     * hit counts don't carry over to a newly-placed block at the same position.
+     */
+    public void clearHits(int x, int y, int z) {
+        blockHits.remove(getBlockKey(x, y, z));
+    }
+
+    /**
      * Reset all hit counters.
      */
     public void resetHits() {

--- a/src/main/java/ragamuffin/core/RagamuffinGame.java
+++ b/src/main/java/ragamuffin/core/RagamuffinGame.java
@@ -241,6 +241,7 @@ public class RagamuffinGame extends ApplicationAdapter {
 
         // Phase 5: Initialize NPC system
         npcManager = new NPCManager();
+        npcManager.setBlockBreaker(blockBreaker);
         spawnInitialNPCs();
 
         // Phase 6: Initialize day/night cycle and lighting
@@ -1438,7 +1439,7 @@ public class RagamuffinGame extends ApplicationAdapter {
         hotbarUI = new HotbarUI(inventory);
         craftingUI = new CraftingUI(craftingSystem, inventory);
 
-        // Reset NPCs
+        // Reset NPCs (blockBreaker wired below after it is re-created)
         npcManager = new NPCManager();
         spawnInitialNPCs();
 
@@ -1449,6 +1450,7 @@ public class RagamuffinGame extends ApplicationAdapter {
 
         // Reset game systems
         blockBreaker = new BlockBreaker();
+        npcManager.setBlockBreaker(blockBreaker);
         tooltipSystem = new TooltipSystem();
         tooltipSystem.setOnTooltipShow(() -> soundSystem.play(ragamuffin.audio.SoundEffect.TOOLTIP));
         interactionSystem = new InteractionSystem();


### PR DESCRIPTION
## Summary
Automated fix for issue #40.

## Changes
- Fix #40: clear stale BlockBreaker hit counter after NPC demolition

Closes #40