### PR TITLE
Fix #42: NPCManager.gameTime never synced with TimeSystem — daily routines frozen at 8 AM

### DIFF
--- a/src/main/java/ragamuffin/core/RagamuffinGame.java
+++ b/src/main/java/ragamuffin/core/RagamuffinGame.java
@@ -493,6 +493,7 @@ public class RagamuffinGame extends ApplicationAdapter {
                 float gameTimeDelta = delta;
 
                 timeSystem.update(delta);
+                npcManager.setGameTime(timeSystem.getTime());
                 lightingSystem.updateLighting(timeSystem.getTime(), timeSystem.getSunriseTime(), timeSystem.getSunsetTime());
                 updateSkyColour(timeSystem.getTime());
                 clockHUD.update(timeSystem.getTime(), timeSystem.getDayCount(), timeSystem.getDayOfMonth(), timeSystem.getMonthName());


### PR DESCRIPTION
## Summary
Automated fix for issue #42.

## Changes
- Fix #42: sync NPCManager.gameTime with TimeSystem each frame

Closes #42