### PR TITLE
Fix #46: Block breaking awards reputation points, making player Notorious after ~30 blocks

### DIFF
--- a/src/main/java/ragamuffin/core/RagamuffinGame.java
+++ b/src/main/java/ragamuffin/core/RagamuffinGame.java
@@ -1022,8 +1022,6 @@ public class RagamuffinGame extends ApplicationAdapter {
                 gameHUD.setBlockBreakProgress(0f);
                 // Play block break sound based on material
                 soundSystem.playBlockBreak(blockType);
-                // Award street reputation for breaking blocks (minor crime)
-                player.getStreetReputation().addPoints(1);
             }
 
             // Consume tool durability if a tool was used

--- a/src/test/java/ragamuffin/integration/Issue46BlockBreakingReputationTest.java
+++ b/src/test/java/ragamuffin/integration/Issue46BlockBreakingReputationTest.java
@@ -1,0 +1,161 @@
+package ragamuffin.integration;
+
+import com.badlogic.gdx.math.Vector3;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import ragamuffin.ai.NPCManager;
+import ragamuffin.building.BlockBreaker;
+import ragamuffin.building.Inventory;
+import ragamuffin.entity.NPC;
+import ragamuffin.entity.NPCState;
+import ragamuffin.entity.NPCType;
+import ragamuffin.entity.Player;
+import ragamuffin.core.StreetReputation;
+import ragamuffin.ui.TooltipSystem;
+import ragamuffin.world.BlockType;
+import ragamuffin.world.World;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Issue #46 Integration Tests — Block breaking must NOT award reputation points.
+ *
+ * Verifies that:
+ * 1. Breaking 50 blocks leaves reputation at 0, player not notorious, no civilians fleeing.
+ * 2. Punching an NPC still awards 2 reputation points (existing behaviour preserved).
+ * 3. After 100 blocks broken at night, police count cap is ≤4, not 8.
+ */
+class Issue46BlockBreakingReputationTest {
+
+    private World world;
+    private Player player;
+    private NPCManager npcManager;
+    private Inventory inventory;
+    private TooltipSystem tooltipSystem;
+    private BlockBreaker blockBreaker;
+
+    @BeforeEach
+    void setUp() {
+        world = new World(12345);
+        player = new Player(0, 1, 0);
+        npcManager = new NPCManager();
+        inventory = new Inventory(36);
+        tooltipSystem = new TooltipSystem();
+        blockBreaker = new BlockBreaker();
+
+        // Flat ground for testing
+        for (int x = -60; x < 60; x++) {
+            for (int z = -60; z < 60; z++) {
+                world.setBlock(x, 0, z, BlockType.GRASS);
+            }
+        }
+    }
+
+    /**
+     * Test 1: Breaking 50 blocks leaves reputation at 0, player not notorious,
+     * and no civilians flee.
+     *
+     * Place 50 TREE_TRUNK blocks and break each one (5 punches each).
+     * Verify reputation stays at 0, player is not NOTORIOUS, and a nearby
+     * PUBLIC civilian does not enter FLEEING state.
+     */
+    @Test
+    void test1_Breaking50BlocksLeavesReputationAtZero() {
+        // Place and break 50 TREE_TRUNK blocks
+        for (int i = 0; i < 50; i++) {
+            world.setBlock(i, 1, 0, BlockType.TREE_TRUNK);
+            for (int hit = 0; hit < 5; hit++) {
+                blockBreaker.punchBlock(world, i, 1, 0);
+            }
+            // Simulate the reputation that handlePunch() would award on break
+            // (i.e. nothing — the fix ensures no addPoints call happens here)
+        }
+
+        // Reputation should be untouched
+        assertEquals(0, player.getStreetReputation().getPoints(),
+            "Reputation should remain 0 after breaking 50 blocks");
+        assertFalse(player.getStreetReputation().isNotorious(),
+            "Player should not be notorious after breaking 50 blocks");
+        assertFalse(player.getStreetReputation().isKnown(),
+            "Player should not even be known after breaking 50 blocks");
+
+        // Spawn a PUBLIC civilian 5 blocks away
+        NPC civilian = npcManager.spawnNPC(NPCType.PUBLIC, 5, 1, 0);
+        assertNotNull(civilian);
+
+        // One update tick
+        npcManager.update(0.016f, world, player, inventory, tooltipSystem);
+
+        assertNotEquals(NPCState.FLEEING, civilian.getState(),
+            "Civilian should NOT flee — player's reputation is 0 after block breaking");
+    }
+
+    /**
+     * Test 2: Punching an NPC still awards 2 reputation points.
+     *
+     * The fix must NOT touch NPC punching. Simulate the reputation award that
+     * RagamuffinGame.handlePunch() applies when an NPC is hit (2 points).
+     * Verify the reputation increases by exactly 2.
+     */
+    @Test
+    void test2_PunchingNPCAwards2ReputationPoints() {
+        assertEquals(0, player.getStreetReputation().getPoints(),
+            "Reputation should start at 0");
+
+        // Simulate what handlePunch() does when an NPC is punched
+        NPC targetNPC = npcManager.spawnNPC(NPCType.PUBLIC, 2, 1, 0);
+        assertNotNull(targetNPC);
+
+        Vector3 punchDirection = new Vector3(1, 0, 0);
+        npcManager.punchNPC(targetNPC, punchDirection, inventory, tooltipSystem);
+        // Award street reputation for fighting (major crime) — unchanged by fix
+        player.getStreetReputation().addPoints(2);
+
+        assertEquals(2, player.getStreetReputation().getPoints(),
+            "Punching an NPC should still award exactly 2 reputation points");
+    }
+
+    /**
+     * Test 3: After 100 blocks broken at night, active police cap is ≤4, not 8.
+     *
+     * Break 100 blocks. Verify player's reputation is still 0 and not notorious.
+     * Call updatePoliceSpawning() at night time and verify the police count
+     * never exceeds 4 (the non-notorious cap), not 8.
+     */
+    @Test
+    void test3_After100BlocksBrokenAtNightPoliceCapIsNotEight() {
+        // Break 100 STONE blocks — simulate the block-breaking path
+        for (int i = 0; i < 100; i++) {
+            world.setBlock(i % 50, 1 + (i / 50), i % 10, BlockType.STONE);
+            for (int hit = 0; hit < 5; hit++) {
+                blockBreaker.punchBlock(world, i % 50, 1 + (i / 50), i % 10);
+            }
+            // No reputation awarded (the fix removes addPoints(1) from this path)
+        }
+
+        // Verify player is NOT notorious
+        assertFalse(player.getStreetReputation().isNotorious(),
+            "Player should NOT be notorious after breaking 100 blocks");
+        assertEquals(0, player.getStreetReputation().getPoints(),
+            "Reputation must stay at 0 after breaking 100 blocks");
+
+        // The police cap formula: notorious ? 8 : 4
+        // Since player is not notorious, maxPolice = 4
+        int maxPolice = player.getStreetReputation().isNotorious() ? 8 : 4;
+        assertEquals(4, maxPolice,
+            "Police cap should be 4 (not 8) when player is not notorious after breaking blocks");
+
+        // Simulate multiple police spawn cycles at night (22:00)
+        float nightTime = 23.0f;
+        for (int cycle = 0; cycle < 10; cycle++) {
+            npcManager.updatePoliceSpawning(nightTime, world, player);
+        }
+
+        long policeCount = npcManager.getNPCs().stream()
+            .filter(n -> n.getType() == NPCType.POLICE && n.isAlive())
+            .count();
+
+        assertTrue(policeCount <= 4,
+            "Police count should be ≤4 after block breaking (player not notorious). Got: " + policeCount);
+    }
+}


### PR DESCRIPTION
## Summary
Automated fix for issue #46.

## Changes
- Fix #46: Block breaking no longer awards reputation points

Closes #46