### PR TITLE
Fix #66: HealingSystem ticks while UI open — free healing exploit bypasses survival loop

### DIFF
--- a/src/main/java/ragamuffin/core/RagamuffinGame.java
+++ b/src/main/java/ragamuffin/core/RagamuffinGame.java
@@ -527,10 +527,10 @@ public class RagamuffinGame extends ApplicationAdapter {
                             player.damage(healthDrain);
                         }
                     }
-                }
 
-                // Phase 11: Update healing system
-                healingSystem.update(delta, player);
+                    // Phase 11: Update healing system (gated: no healing while UI is open)
+                    healingSystem.update(delta, player);
+                }
 
                 // Phase 11: Check for death and respawn
                 respawnSystem.checkAndTriggerRespawn(player, tooltipSystem);


### PR DESCRIPTION
## Summary
Automated fix for issue #66.

## Changes
- Fix #66: Move healingSystem.update() inside !isUIBlocking() guard

Closes #66