### PR TITLE
Fix #108: StructureTracker detects world-generated allotments fence as a player structure

### DIFF
--- a/src/main/java/ragamuffin/world/BlockType.java
+++ b/src/main/java/ragamuffin/world/BlockType.java
@@ -48,7 +48,9 @@ public enum BlockType {
     CARPET(38, true),      // Floor carpet
     LINO_GREEN(39, true),  // Cheap lino flooring
     BOOKSHELF(40, true),   // Library bookshelf
-    BEDROCK(41, true);     // Indestructible bottom layer
+    BEDROCK(41, true),     // Indestructible bottom layer
+    WOOD_FENCE(42, true),  // World-generated wooden fence (not player-placeable)
+    WOOD_WALL(43, true);   // World-generated wooden wall/shed (not player-placeable)
 
     private final int id;
     private final boolean solid;
@@ -119,6 +121,8 @@ public enum BlockType {
             case ROOF_TILE:
             case SLATE:
             case WOOD:
+            case WOOD_FENCE:
+            case WOOD_WALL:
             case TREE_TRUNK:
             case BOOKSHELF:
             case CARDBOARD:
@@ -181,6 +185,8 @@ public enum BlockType {
                     clamp01(base.b + variation * 0.5f), base.a);
 
             case WOOD:
+            case WOOD_FENCE:
+            case WOOD_WALL:
             case TREE_TRUNK:
                 // Wood grain — darken every other row
                 boolean isGrainLine = (worldY % 2 == 0);
@@ -272,6 +278,8 @@ public enum BlockType {
             case LINO_GREEN: return new Color(0.35f, 0.52f, 0.30f, 1f);  // Hospital green
             case BOOKSHELF: return new Color(0.38f, 0.28f, 0.12f, 1f);   // Dark walnut
             case BEDROCK: return new Color(0.15f, 0.15f, 0.15f, 1f);   // Very dark grey
+            case WOOD_FENCE: return new Color(0.72f, 0.52f, 0.28f, 1f); // Same as WOOD
+            case WOOD_WALL: return new Color(0.72f, 0.52f, 0.28f, 1f);  // Same as WOOD
             default: return new Color(1f, 1f, 1f, 1f);
         }
     }
@@ -298,6 +306,8 @@ public enum BlockType {
             case CARPET: return new Color(0.48f, 0.15f, 0.15f, 1f);      // Slightly different pile
             case WOOD: return new Color(0.68f, 0.50f, 0.25f, 1f);        // End grain
             case CARDBOARD: return new Color(0.72f, 0.60f, 0.35f, 1f);   // Flap edge
+            case WOOD_FENCE: return new Color(0.68f, 0.50f, 0.25f, 1f);  // End grain
+            case WOOD_WALL: return new Color(0.68f, 0.50f, 0.25f, 1f);   // End grain
             default: return buildSideColor();
         }
     }

--- a/src/main/java/ragamuffin/world/WorldGenerator.java
+++ b/src/main/java/ragamuffin/world/WorldGenerator.java
@@ -1118,14 +1118,14 @@ public class WorldGenerator {
         // Perimeter fence (wooden, 2 blocks high)
         for (int dx = 0; dx < width; dx++) {
             for (int y = 1; y <= 2; y++) {
-                world.setBlock(x + dx, y, z, BlockType.WOOD);
-                world.setBlock(x + dx, y, z + depth - 1, BlockType.WOOD);
+                world.setBlock(x + dx, y, z, BlockType.WOOD_FENCE);
+                world.setBlock(x + dx, y, z + depth - 1, BlockType.WOOD_FENCE);
             }
         }
         for (int dz = 0; dz < depth; dz++) {
             for (int y = 1; y <= 2; y++) {
-                world.setBlock(x, y, z + dz, BlockType.WOOD);
-                world.setBlock(x + width - 1, y, z + dz, BlockType.WOOD);
+                world.setBlock(x, y, z + dz, BlockType.WOOD_FENCE);
+                world.setBlock(x + width - 1, y, z + dz, BlockType.WOOD_FENCE);
             }
         }
 
@@ -1169,7 +1169,7 @@ public class WorldGenerator {
                 for (int dz = 0; dz < depth; dz++) {
                     boolean isWall = dx == 0 || dx == width - 1 || dz == 0 || dz == depth - 1;
                     if (isWall) {
-                        world.setBlock(x + dx, y, z + dz, BlockType.WOOD);
+                        world.setBlock(x + dx, y, z + dz, BlockType.WOOD_WALL);
                     }
                 }
             }

--- a/src/test/java/ragamuffin/integration/Issue108AllotmentsFenceTest.java
+++ b/src/test/java/ragamuffin/integration/Issue108AllotmentsFenceTest.java
@@ -1,0 +1,138 @@
+package ragamuffin.integration;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import ragamuffin.ai.NPCManager;
+import ragamuffin.building.Inventory;
+import ragamuffin.entity.NPCType;
+import ragamuffin.test.HeadlessTestHelper;
+import ragamuffin.ui.TooltipSystem;
+import ragamuffin.world.BlockType;
+import ragamuffin.world.World;
+import ragamuffin.entity.Player;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Integration tests for Issue #108:
+ * StructureTracker detects world-generated allotments fence as a player structure.
+ *
+ * Fix: generateAllotments() and buildShed() now use WOOD_FENCE and WOOD_WALL
+ * instead of WOOD. StructureTracker only scans for WOOD, so world-generated
+ * allotments are no longer treated as player structures.
+ */
+class Issue108AllotmentsFenceTest {
+
+    private World world;
+    private Player player;
+    private NPCManager npcManager;
+    private TooltipSystem tooltipSystem;
+
+    // Allotments are placed at (60, 0, -100), width=30, depth=20 by WorldGenerator
+    private static final int ALLOTMENTS_X = 60;
+    private static final int ALLOTMENTS_Z = -100;
+    private static final int ALLOTMENTS_WIDTH = 30;
+    private static final int ALLOTMENTS_DEPTH = 20;
+
+    @BeforeEach
+    void setUp() {
+        HeadlessTestHelper.initHeadless();
+        world = new World(0);
+        world.generate();
+        player = new Player(0, 1, 0);
+        npcManager = new NPCManager();
+        tooltipSystem = new TooltipSystem();
+    }
+
+    /**
+     * Test 1: Generate world, force structure scan immediately, verify:
+     * - structureTracker.getStructures() is empty
+     * - no COUNCIL_BUILDER NPCs spawned
+     * - allotments fence blocks are intact (non-AIR)
+     */
+    @Test
+    void worldGeneratedAllotmentsFenceDoesNotTriggerCouncilBuilders() {
+        // Force structure scan immediately after world generation
+        npcManager.forceStructureScan(world, tooltipSystem);
+
+        // Verify no structures detected from world-generated blocks
+        assertEquals(0, npcManager.getStructureTracker().getStructures().size(),
+                "World-generated allotments fence should NOT be detected as a player structure");
+
+        // Verify no council builders spawned
+        long builderCount = npcManager.getNPCs().stream()
+                .filter(npc -> npc.getType() == NPCType.COUNCIL_BUILDER)
+                .count();
+        assertEquals(0, builderCount,
+                "No COUNCIL_BUILDER NPCs should spawn for world-generated allotments fence");
+
+        // Verify allotments fence blocks are still intact (using WOOD_FENCE, not AIR)
+        BlockType fenceBlock = world.getBlock(ALLOTMENTS_X, 1, ALLOTMENTS_Z);
+        assertNotEquals(BlockType.AIR, fenceBlock,
+                "Allotments fence blocks should be intact (not AIR) after scan");
+        assertEquals(BlockType.WOOD_FENCE, fenceBlock,
+                "Allotments perimeter fence should use WOOD_FENCE block type");
+    }
+
+    /**
+     * Test 2: Place 15 WOOD blocks in a connected cluster, force scan, verify:
+     * - exactly one structure detected
+     * - a council builder spawned
+     */
+    @Test
+    void playerBuiltWoodStructureStillTriggersCouncilBuilders() {
+        // Place 15 WOOD blocks in a connected cluster (3x5x1), far from allotments
+        for (int x = 10; x < 13; x++) {
+            for (int y = 1; y < 6; y++) {
+                world.setBlock(x, y, 10, BlockType.WOOD);
+            }
+        }
+        // That's 3*5 = 15 WOOD blocks — above the 10-block threshold
+
+        // Force structure scan
+        npcManager.forceStructureScan(world, tooltipSystem);
+
+        // Verify exactly one structure detected
+        assertEquals(1, npcManager.getStructureTracker().getStructures().size(),
+                "Exactly one WOOD structure should be detected");
+
+        // Verify a COUNCIL_BUILDER NPC has been spawned
+        long builderCount = npcManager.getNPCs().stream()
+                .filter(npc -> npc.getType() == NPCType.COUNCIL_BUILDER)
+                .count();
+        assertTrue(builderCount >= 1,
+                "At least 1 COUNCIL_BUILDER NPC should spawn for a large WOOD structure");
+    }
+
+    /**
+     * Test 3: Regression — verify neither allotments fence nor sheds are detected
+     * as structures at game start. The allotments perimeter (30x20, 2 heights = ~200
+     * WOOD_FENCE blocks) and sheds (WOOD_WALL) must not appear in structure list.
+     */
+    @Test
+    void allotmentsFenceAndShedsNotDetectedAsStructures() {
+        // Force structure scan
+        npcManager.forceStructureScan(world, tooltipSystem);
+
+        // Confirm allotments fence uses WOOD_FENCE (not WOOD)
+        // Check multiple fence positions around the perimeter
+        // North fence (z = ALLOTMENTS_Z, various x positions)
+        assertEquals(BlockType.WOOD_FENCE, world.getBlock(ALLOTMENTS_X, 1, ALLOTMENTS_Z),
+                "North fence should be WOOD_FENCE");
+        assertEquals(BlockType.WOOD_FENCE, world.getBlock(ALLOTMENTS_X + ALLOTMENTS_WIDTH - 1, 1, ALLOTMENTS_Z),
+                "North-east corner fence should be WOOD_FENCE");
+        // South fence (z = ALLOTMENTS_Z + depth - 1)
+        assertEquals(BlockType.WOOD_FENCE, world.getBlock(ALLOTMENTS_X, 1, ALLOTMENTS_Z + ALLOTMENTS_DEPTH - 1),
+                "South fence should be WOOD_FENCE");
+
+        // Confirm sheds use WOOD_WALL
+        // Shed 1 is at (x+2, z+2) = (62, 1, -98), width=2, depth=2.
+        // The door is at (x+2, 1, z+2) = (62, 1, -98), so check the adjacent wall at (63, 1, -98).
+        assertEquals(BlockType.WOOD_WALL, world.getBlock(ALLOTMENTS_X + 3, 1, ALLOTMENTS_Z + 2),
+                "Shed wall should be WOOD_WALL");
+
+        // Structure tracker should have found nothing
+        assertEquals(0, npcManager.getStructureTracker().getStructures().size(),
+                "No structures should be detected from world-generated allotments");
+    }
+}


### PR DESCRIPTION
## Summary
Automated fix for issue #108.

## Changes
- Fix #108: add WOOD_FENCE/WOOD_WALL to stop allotments triggering council builders

Closes #108