### PR TITLE
Fix #110: Police spawn window doesn't match TimeSystem.isNight() — HUD and cold snap fire hours before police arrive

### DIFF
--- a/src/main/java/ragamuffin/ai/NPCManager.java
+++ b/src/main/java/ragamuffin/ai/NPCManager.java
@@ -1312,12 +1312,13 @@ public class NPCManager {
     }
 
     /**
-     * Update police spawning — police patrol at night (22:00-06:00). At dawn, all police
-     * are despawned. At night, officers are spawned up to the cap based on player notoriety.
+     * Update police spawning — police patrol at night (seasonal: after sunset, before sunrise).
+     * At dawn, all police are despawned. At night, officers are spawned up to the cap based on
+     * player notoriety.
+     *
+     * @param isNight true if it is currently night (from TimeSystem.isNight())
      */
-    public void updatePoliceSpawning(float time, World world, Player player) {
-        boolean isNight = time >= 22.0f || time < 6.0f;
-
+    public void updatePoliceSpawning(boolean isNight, World world, Player player) {
         // Despawn police at dawn (night → day transition)
         if (wasNight && !isNight) {
             despawnPolice();

--- a/src/main/java/ragamuffin/core/RagamuffinGame.java
+++ b/src/main/java/ragamuffin/core/RagamuffinGame.java
@@ -493,8 +493,8 @@ public class RagamuffinGame extends ApplicationAdapter {
                 float gameTimeDeltaSeconds = delta * timeSystem.getTimeSpeed() * 3600f;
                 weatherSystem.update(gameTimeDeltaSeconds);
 
-                // Update police spawning based on time
-                npcManager.updatePoliceSpawning(timeSystem.getTime(), world, player);
+                // Update police spawning based on seasonal night (TimeSystem.isNight())
+                npcManager.updatePoliceSpawning(timeSystem.isNight(), world, player);
 
                 // Update player survival stats (gated: no hunger/starvation/cold-snap while UI is open)
                 if (!isUIBlocking()) {

--- a/src/test/java/ragamuffin/ai/NPCManagerTest.java
+++ b/src/test/java/ragamuffin/ai/NPCManagerTest.java
@@ -194,8 +194,8 @@ class NPCManagerTest {
                 .filter(n -> n.getType() == NPCType.POLICE && n.isAlive()).count();
         assertEquals(3, beforeCount, "Expected 3 police before daytime update");
 
-        // Simulate a daytime frame at 8:00 AM — police must NOT be despawned
-        manager.updatePoliceSpawning(8.0f, world, player);
+        // Simulate a daytime frame (isNight=false) — police must NOT be despawned
+        manager.updatePoliceSpawning(false, world, player);
 
         long afterCount = manager.getNPCs().stream()
                 .filter(n -> n.getType() == NPCType.POLICE && n.isAlive()).count();
@@ -215,7 +215,7 @@ class NPCManagerTest {
         // Call at night — the cap is 4, so a 4th officer should eventually be spawned.
         // Reset cooldown by direct inspection isn't possible, but we can verify the
         // daytime call with exactly-cap police does NOT add more.
-        manager.updatePoliceSpawning(8.0f, world, player); // daytime, cap=3, already have 3 → no spawn
+        manager.updatePoliceSpawning(false, world, player); // daytime, cap=3, already have 3 → no spawn
         long countAfterDay = manager.getNPCs().stream()
                 .filter(n -> n.getType() == NPCType.POLICE && n.isAlive()).count();
         assertEquals(3, countAfterDay, "Daytime should not spawn extra police beyond cap of 3");
@@ -231,7 +231,7 @@ class NPCManagerTest {
         manager.spawnNPC(NPCType.POLICE, 10, 1, 5);
 
         // Fresh manager: cooldown is 0, so updatePoliceSpawning will execute immediately.
-        manager.updatePoliceSpawning(8.0f, world, player); // daytime, cap=3, have 2 → 1 slot
+        manager.updatePoliceSpawning(false, world, player); // daytime, cap=3, have 2 → 1 slot
 
         long policeCount = manager.getNPCs().stream()
                 .filter(n -> n.getType() == NPCType.POLICE && n.isAlive()).count();

--- a/src/test/java/ragamuffin/integration/Issue46BlockBreakingReputationTest.java
+++ b/src/test/java/ragamuffin/integration/Issue46BlockBreakingReputationTest.java
@@ -145,10 +145,9 @@ class Issue46BlockBreakingReputationTest {
         assertEquals(4, maxPolice,
             "Police cap should be 4 (not 8) when player is not notorious after breaking blocks");
 
-        // Simulate multiple police spawn cycles at night (22:00)
-        float nightTime = 23.0f;
+        // Simulate multiple police spawn cycles at night (isNight=true)
         for (int cycle = 0; cycle < 10; cycle++) {
-            npcManager.updatePoliceSpawning(nightTime, world, player);
+            npcManager.updatePoliceSpawning(true, world, player);
         }
 
         long policeCount = npcManager.getNPCs().stream()

--- a/src/test/java/ragamuffin/integration/Phase6IntegrationTest.java
+++ b/src/test/java/ragamuffin/integration/Phase6IntegrationTest.java
@@ -169,7 +169,7 @@ class Phase6IntegrationTest {
     void test3_PoliceSpawnAtNightDespawnAtDawn() {
         // Set to 22:00 (night) — police should spawn
         timeSystem.setTime(22.0f);
-        npcManager.updatePoliceSpawning(timeSystem.getTime(), world, player);
+        npcManager.updatePoliceSpawning(timeSystem.isNight(), world, player);
 
         // Count POLICE NPCs — at least some should exist now
         long policeCountNight = npcManager.getNPCs().stream()
@@ -181,7 +181,7 @@ class Phase6IntegrationTest {
 
         // Advance to 06:00 (morning / dawn) — police must be despawned
         timeSystem.setTime(6.0f);
-        npcManager.updatePoliceSpawning(timeSystem.getTime(), world, player);
+        npcManager.updatePoliceSpawning(timeSystem.isNight(), world, player);
 
         long policeCountMorning = npcManager.getNPCs().stream()
                 .filter(npc -> npc.getType() == NPCType.POLICE && npc.isAlive())
@@ -260,7 +260,7 @@ class Phase6IntegrationTest {
 
         // Set to 22:00
         timeSystem.setTime(22.0f);
-        npcManager.updatePoliceSpawning(timeSystem.getTime(), world, player);
+        npcManager.updatePoliceSpawning(timeSystem.isNight(), world, player);
 
         // Position police close to structure
         for (NPC npc : npcManager.getNPCs()) {
@@ -336,7 +336,7 @@ class Phase6IntegrationTest {
 
         // Set to 22:00
         timeSystem.setTime(22.0f);
-        npcManager.updatePoliceSpawning(timeSystem.getTime(), world, player);
+        npcManager.updatePoliceSpawning(timeSystem.isNight(), world, player);
 
         // Get police NPC
         NPC police = npcManager.getNPCs().stream()
@@ -393,7 +393,7 @@ class Phase6IntegrationTest {
 
         // Set to 22:00 (night) and spawn police
         timeSystem.setTime(22.0f);
-        npcManager.updatePoliceSpawning(timeSystem.getTime(), world, player);
+        npcManager.updatePoliceSpawning(timeSystem.isNight(), world, player);
 
         // Position police near player
         for (NPC npc : npcManager.getNPCs()) {
@@ -432,7 +432,7 @@ class Phase6IntegrationTest {
 
         // Set to 22:00 (night) and spawn police
         timeSystem.setTime(22.0f);
-        npcManager.updatePoliceSpawning(timeSystem.getTime(), world, player);
+        npcManager.updatePoliceSpawning(timeSystem.isNight(), world, player);
 
         // Position police right next to the player (within 2 blocks) so WARNING
         // triggers immediately on frame 1, and the structure is within 20 blocks.
@@ -478,7 +478,7 @@ class Phase6IntegrationTest {
 
         // Set to 22:00
         timeSystem.setTime(22.0f);
-        npcManager.updatePoliceSpawning(timeSystem.getTime(), world, player);
+        npcManager.updatePoliceSpawning(timeSystem.isNight(), world, player);
 
         // Get police
         NPC police = npcManager.getNPCs().stream()
@@ -539,7 +539,7 @@ class Phase6IntegrationTest {
     void testIssue102_PoliceDespawnAtDawn() {
         // Night: spawn police
         timeSystem.setTime(22.0f);
-        npcManager.updatePoliceSpawning(timeSystem.getTime(), world, player);
+        npcManager.updatePoliceSpawning(timeSystem.isNight(), world, player);
 
         long policeAtNight = npcManager.getNPCs().stream()
                 .filter(npc -> npc.getType() == NPCType.POLICE && npc.isAlive())
@@ -548,7 +548,7 @@ class Phase6IntegrationTest {
 
         // Dawn transition: despawn police
         timeSystem.setTime(6.0f);
-        npcManager.updatePoliceSpawning(timeSystem.getTime(), world, player);
+        npcManager.updatePoliceSpawning(timeSystem.isNight(), world, player);
 
         long policeAtDawn = npcManager.getNPCs().stream()
                 .filter(npc -> npc.getType() == NPCType.POLICE && npc.isAlive())
@@ -566,7 +566,7 @@ class Phase6IntegrationTest {
         // --- Cycle 1 ---
         // Night 1: spawn police
         timeSystem.setTime(22.0f);
-        npcManager.updatePoliceSpawning(timeSystem.getTime(), world, player);
+        npcManager.updatePoliceSpawning(timeSystem.isNight(), world, player);
 
         long policeNight1 = npcManager.getNPCs().stream()
                 .filter(npc -> npc.getType() == NPCType.POLICE && npc.isAlive())
@@ -576,7 +576,7 @@ class Phase6IntegrationTest {
 
         // Dawn 1: despawn
         timeSystem.setTime(6.0f);
-        npcManager.updatePoliceSpawning(timeSystem.getTime(), world, player);
+        npcManager.updatePoliceSpawning(timeSystem.isNight(), world, player);
 
         long policeDawn1 = npcManager.getNPCs().stream()
                 .filter(npc -> npc.getType() == NPCType.POLICE && npc.isAlive())
@@ -589,7 +589,7 @@ class Phase6IntegrationTest {
         // --- Cycle 2 ---
         // Night 2: spawn police
         timeSystem.setTime(22.0f);
-        npcManager.updatePoliceSpawning(timeSystem.getTime(), world, player);
+        npcManager.updatePoliceSpawning(timeSystem.isNight(), world, player);
 
         long policeNight2 = npcManager.getNPCs().stream()
                 .filter(npc -> npc.getType() == NPCType.POLICE && npc.isAlive())
@@ -599,7 +599,7 @@ class Phase6IntegrationTest {
 
         // Dawn 2: despawn
         timeSystem.setTime(6.0f);
-        npcManager.updatePoliceSpawning(timeSystem.getTime(), world, player);
+        npcManager.updatePoliceSpawning(timeSystem.isNight(), world, player);
 
         long policeDawn2 = npcManager.getNPCs().stream()
                 .filter(npc -> npc.getType() == NPCType.POLICE && npc.isAlive())
@@ -616,7 +616,7 @@ class Phase6IntegrationTest {
     void testIssue102_FreshPoliceSpawnAfterDawnDespawn() {
         // Night 1: spawn police
         timeSystem.setTime(22.0f);
-        npcManager.updatePoliceSpawning(timeSystem.getTime(), world, player);
+        npcManager.updatePoliceSpawning(timeSystem.isNight(), world, player);
 
         List<NPC> policeList = npcManager.getNPCs().stream()
                 .filter(npc -> npc.getType() == NPCType.POLICE && npc.isAlive())
@@ -629,7 +629,7 @@ class Phase6IntegrationTest {
 
         // Dawn: despawn all remaining police
         timeSystem.setTime(6.0f);
-        npcManager.updatePoliceSpawning(timeSystem.getTime(), world, player);
+        npcManager.updatePoliceSpawning(timeSystem.isNight(), world, player);
 
         long policeDawn = npcManager.getNPCs().stream()
                 .filter(npc -> npc.getType() == NPCType.POLICE && npc.isAlive())
@@ -641,7 +641,7 @@ class Phase6IntegrationTest {
 
         // Night 2: fresh police should spawn
         timeSystem.setTime(22.0f);
-        npcManager.updatePoliceSpawning(timeSystem.getTime(), world, player);
+        npcManager.updatePoliceSpawning(timeSystem.isNight(), world, player);
 
         long policeNight2 = npcManager.getNPCs().stream()
                 .filter(npc -> npc.getType() == NPCType.POLICE && npc.isAlive())


### PR DESCRIPTION
## Summary
Automated fix for issue #110.

## Changes
- Fix #110: use TimeSystem.isNight() in updatePoliceSpawning() instead of hardcoded 22:00-06:00

Closes #110