### PR TITLE
Fix #114: Reset Greggs raid state on player respawn

### DIFF
--- a/src/main/java/ragamuffin/core/RagamuffinGame.java
+++ b/src/main/java/ragamuffin/core/RagamuffinGame.java
@@ -532,6 +532,8 @@ public class RagamuffinGame extends ApplicationAdapter {
                 respawnSystem.update(delta, player);
                 if (wasRespawning && !respawnSystem.isRespawning()) {
                     deathMessage = null; // Reset for next death
+                    // Issue #114: Reset Greggs raid on respawn — mirrors the arrest-handler reset
+                    greggsRaidSystem.reset();
                 }
 
                 // Phase 11: Trigger hunger warning tooltip


### PR DESCRIPTION
## Summary
Automated fix for issue #114.

## Changes
- Fix #114: call greggsRaidSystem.reset() on player respawn

Closes #114