### PR TITLE
Fix #116: Sprint never drains energy — energy bar is irrelevant to movement

### DIFF
--- a/src/main/java/ragamuffin/core/RagamuffinGame.java
+++ b/src/main/java/ragamuffin/core/RagamuffinGame.java
@@ -502,6 +502,11 @@ public class RagamuffinGame extends ApplicationAdapter {
                     float hungerMultiplier = inputHandler.isSprintHeld() ? 3.0f : 1.0f;
                     player.updateHunger(delta * hungerMultiplier);
 
+                    // Sprint drains energy while moving
+                    if (inputHandler.isSprintHeld() && tmpMoveDir.len2() > 0) {
+                        player.consumeEnergy(Player.SPRINT_ENERGY_DRAIN * delta);
+                    }
+
                     // Starvation: zero hunger drains health at 5 HP/s
                     if (player.getHunger() <= 0) {
                         player.damage(5.0f * delta);

--- a/src/main/java/ragamuffin/entity/Player.java
+++ b/src/main/java/ragamuffin/entity/Player.java
@@ -31,6 +31,7 @@ public class Player {
     public static final float HUNGER_DRAIN_PER_MINUTE = 2f; // 50 minutes to starve
     public static final float ENERGY_DRAIN_PER_ACTION = 1f;
     public static final float ENERGY_RECOVERY_PER_SECOND = 5f; // 20 seconds to full recovery
+    public static final float SPRINT_ENERGY_DRAIN = 8.0f; // Energy/s drained while sprinting and moving
 
     private final Vector3 position;
     private final Vector3 velocity;


### PR DESCRIPTION
## Summary
Automated fix for issue #116.

## Changes
- Fix #116: drain energy at 8.0/s while sprinting and moving

Closes #116