### PR TITLE
Fix #126: Youth gang theft only steals WOOD — ignores all other inventory items

### DIFF
--- a/src/main/java/ragamuffin/ai/NPCManager.java
+++ b/src/main/java/ragamuffin/ai/NPCManager.java
@@ -701,15 +701,55 @@ public class NPCManager {
 
     /**
      * Attempt to steal from player inventory.
+     * Steals the most valuable item available, using priority order:
+     * DIAMOND > SCRAP_METAL > BRICK > WOOD > food items.
+     * Falls back to a random non-empty slot if no priority item is found.
      */
     private void attemptTheft(Inventory inventory, TooltipSystem tooltipSystem) {
-        // Try to steal wood first
-        if (inventory.getItemCount(Material.WOOD) > 0) {
-            inventory.removeItem(Material.WOOD, 1);
-            if (tooltipSystem != null) {
-                tooltipSystem.trigger(TooltipTrigger.YOUTH_THEFT);
+        // Priority order: most valuable first
+        Material[] priority = {
+            Material.DIAMOND,
+            Material.SCRAP_METAL,
+            Material.BRICK,
+            Material.WOOD,
+            Material.SAUSAGE_ROLL,
+            Material.STEAK_BAKE,
+            Material.CRISPS,
+            Material.CHIPS,
+            Material.KEBAB,
+            Material.ENERGY_DRINK,
+            Material.TIN_OF_BEANS,
+            Material.PINT,
+            Material.PERI_PERI_CHICKEN
+        };
+
+        // Try to steal highest-priority item first
+        for (Material m : priority) {
+            if (inventory.getItemCount(m) > 0) {
+                inventory.removeItem(m, 1);
+                if (tooltipSystem != null) {
+                    tooltipSystem.trigger(TooltipTrigger.YOUTH_THEFT);
+                }
+                return;
             }
         }
+
+        // Fall back to a random non-empty slot
+        int size = inventory.getSize();
+        int startSlot = random.nextInt(size);
+        for (int i = 0; i < size; i++) {
+            int slot = (startSlot + i) % size;
+            Material m = inventory.getItemInSlot(slot);
+            if (m != null && inventory.getItemCount(m) > 0) {
+                inventory.removeItem(m, 1);
+                if (tooltipSystem != null) {
+                    tooltipSystem.trigger(TooltipTrigger.YOUTH_THEFT);
+                }
+                return;
+            }
+        }
+
+        // Inventory is completely empty — do nothing
     }
 
     /**

--- a/src/test/java/ragamuffin/ai/NPCManagerTest.java
+++ b/src/test/java/ragamuffin/ai/NPCManagerTest.java
@@ -260,6 +260,50 @@ class NPCManagerTest {
     }
 
     /**
+     * Fix #126: Youth gang steals highest-priority item (DIAMOND over WOOD).
+     */
+    @Test
+    void testYouthGangStealsDiamondOverWood() {
+        NPC youth = manager.spawnNPC(NPCType.YOUTH_GANG, 0.5f, 1, 0.5f);
+        player.getPosition().set(0, 1, 0);
+        inventory.addItem(Material.WOOD, 5);
+        inventory.addItem(Material.DIAMOND, 3);
+
+        // Update until theft occurs
+        for (int i = 0; i < 100; i++) {
+            manager.update(0.1f, world, player, inventory, tooltipSystem);
+            if (inventory.getItemCount(Material.DIAMOND) < 3 || inventory.getItemCount(Material.WOOD) < 5) {
+                break;
+            }
+        }
+
+        // Gang should have stolen DIAMOND (highest priority), not WOOD
+        assertTrue(inventory.getItemCount(Material.DIAMOND) < 3, "Gang should steal DIAMOND first");
+        assertEquals(5, inventory.getItemCount(Material.WOOD), "WOOD should be untouched when DIAMOND is present");
+    }
+
+    /**
+     * Fix #126: Youth gang steals from non-WOOD inventory when no WOOD is present.
+     */
+    @Test
+    void testYouthGangStealsWhenNoWood() {
+        NPC youth = manager.spawnNPC(NPCType.YOUTH_GANG, 0.5f, 1, 0.5f);
+        player.getPosition().set(0, 1, 0);
+        inventory.addItem(Material.SCRAP_METAL, 4);
+
+        // Update until theft occurs
+        for (int i = 0; i < 100; i++) {
+            manager.update(0.1f, world, player, inventory, tooltipSystem);
+            if (inventory.getItemCount(Material.SCRAP_METAL) < 4) {
+                break;
+            }
+        }
+
+        // Gang should have stolen SCRAP_METAL even though there's no WOOD
+        assertTrue(inventory.getItemCount(Material.SCRAP_METAL) < 4, "Gang should steal SCRAP_METAL when no WOOD present");
+    }
+
+    /**
      * Integration test for issue #120: NPC immediately after a council builder that
      * finishes demolishing must not be skipped when the builder is removed.
      *


### PR DESCRIPTION
## Summary
Automated fix for issue #126.

## Changes
- Fix #126: Youth gang theft uses priority-based system — steals most valuable item

Closes #126