### PR TITLE
Fix #136: renderRain() missing orthographic projection — rain overlay invisible during RAIN weather

### DIFF
--- a/src/main/java/ragamuffin/core/RagamuffinGame.java
+++ b/src/main/java/ragamuffin/core/RagamuffinGame.java
@@ -1801,6 +1801,9 @@ public class RagamuffinGame extends ApplicationAdapter {
         Gdx.gl.glEnable(GL20.GL_BLEND);
         Gdx.gl.glBlendFunc(GL20.GL_SRC_ALPHA, GL20.GL_ONE_MINUS_SRC_ALPHA);
 
+        com.badlogic.gdx.math.Matrix4 rainOrtho = new com.badlogic.gdx.math.Matrix4();
+        rainOrtho.setToOrtho2D(0, 0, screenWidth, screenHeight);
+        shapeRenderer.setProjectionMatrix(rainOrtho);
         shapeRenderer.begin(ShapeRenderer.ShapeType.Line);
         shapeRenderer.setColor(0.7f, 0.7f, 0.85f, 0.4f);
 


### PR DESCRIPTION
## Summary
Automated fix for issue #136.

## Changes
- Fix #136: Add orthographic projection to renderRain() so rain overlay is visible

Closes #136