### PR TITLE
Fix #156: StructureTracker only detects WOOD blocks — council enforcement ignores all other build materials

### DIFF
--- a/src/main/java/ragamuffin/building/BlockPlacer.java
+++ b/src/main/java/ragamuffin/building/BlockPlacer.java
@@ -138,11 +138,11 @@ public class BlockPlacer {
             return false;
         }
 
-        // Place the block
+        // Place the block, recording it as player-placed for council enforcement
         int bx = (int) Math.floor(placement.x);
         int by = (int) Math.floor(placement.y);
         int bz = (int) Math.floor(placement.z);
-        world.setBlock(bx, by, bz, blockType);
+        world.setPlayerBlock(bx, by, bz, blockType);
         if (blockBreaker != null) {
             blockBreaker.clearHits(bx, by, bz);
         }
@@ -199,7 +199,7 @@ public class BlockPlacer {
 
     private void setIfAir(World world, int x, int y, int z, BlockType type) {
         if (world.getBlock(x, y, z) == BlockType.AIR) {
-            world.setBlock(x, y, z, type);
+            world.setPlayerBlock(x, y, z, type);
             if (blockBreaker != null) {
                 blockBreaker.clearHits(x, y, z);
             }

--- a/src/main/java/ragamuffin/building/StructureTracker.java
+++ b/src/main/java/ragamuffin/building/StructureTracker.java
@@ -8,7 +8,8 @@ import java.util.*;
 
 /**
  * Tracks player-built structures for council detection.
- * A structure is a connected group of placed blocks (WOOD, BRICK).
+ * A structure is a connected group of player-placeable blocks (WOOD, BRICK, STONE,
+ * GLASS, CARDBOARD, CONCRETE, ROOF_TILE, CORRUGATED_METAL, DOOR_WOOD, and others).
  */
 public class StructureTracker {
 
@@ -110,8 +111,8 @@ public class StructureTracker {
                     }
 
                     BlockType block = world.getBlock(x, y, z);
-                    if (block == BlockType.WOOD) {
-                        // Found a placed block - trace the structure
+                    if (block.isPlayerPlaceable() && world.isPlayerPlaced(x, y, z)) {
+                        // Found a player-placed block - trace the structure
                         Set<Vector3> structureBlocks = traceStructure(world, x, y, z, visited);
                         if (structureBlocks.size() >= SMALL_STRUCTURE_THRESHOLD) {
                             structures.add(new Structure(structureBlocks));
@@ -146,7 +147,7 @@ public class StructureTracker {
                 if (!visited.contains(key)) {
                     visited.add(key);
                     BlockType block = world.getBlock(x, y, z);
-                    if (block == BlockType.WOOD) {
+                    if (block.isPlayerPlaceable() && world.isPlayerPlaced(x, y, z)) {
                         queue.add(new Vector3(x, y, z));
                     }
                 }

--- a/src/main/java/ragamuffin/world/BlockType.java
+++ b/src/main/java/ragamuffin/world/BlockType.java
@@ -157,6 +157,53 @@ public enum BlockType {
     }
 
     /**
+     * Whether this block can be placed by a player when building a shelter.
+     * Used by StructureTracker to detect player-built structures.
+     * Excludes natural world-gen blocks (GRASS, DIRT, PAVEMENT, ROAD, LEAVES,
+     * TREE_TRUNK, WATER, TARMAC) and indestructible/special blocks (BEDROCK,
+     * WOOD_FENCE, WOOD_WALL, FENCE_THIN, DOOR_LOWER, DOOR_UPPER).
+     */
+    public boolean isPlayerPlaceable() {
+        switch (this) {
+            case WOOD:
+            case BRICK:
+            case STONE:
+            case GLASS:
+            case CARDBOARD:
+            case CONCRETE:
+            case ROOF_TILE:
+            case CORRUGATED_METAL:
+            case DOOR_WOOD:
+            case IRON_FENCE:
+            case RENDER_WHITE:
+            case RENDER_CREAM:
+            case RENDER_PINK:
+            case SLATE:
+            case PEBBLEDASH:
+            case YELLOW_BRICK:
+            case GARDEN_WALL:
+            case LINOLEUM:
+            case TILE_WHITE:
+            case TILE_BLACK:
+            case CARPET:
+            case LINO_GREEN:
+            case COUNTER:
+            case SHELF:
+            case TABLE:
+            case BOOKSHELF:
+            case METAL_RED:
+            case SIGN_WHITE:
+            case SIGN_RED:
+            case SIGN_BLUE:
+            case SIGN_GREEN:
+            case SIGN_YELLOW:
+                return true;
+            default:
+                return false;
+        }
+    }
+
+    /**
      * Whether this block type needs per-block colour variation (skips greedy merge).
      * Used for blocks like brick that need mortar lines / individual texture.
      */

--- a/src/main/java/ragamuffin/world/World.java
+++ b/src/main/java/ragamuffin/world/World.java
@@ -35,6 +35,7 @@ public class World {
     private final Set<String> planningNoticeBlocks; // Blocks with planning notices (Phase 7)
     private final Set<String> dirtyChunks; // Chunks needing mesh rebuild
     private final Set<String> openDoors; // Open door positions (world coords of DOOR_LOWER)
+    private final Set<String> playerPlacedBlocks; // Positions where player has placed blocks
 
     public World(long seed) {
         this.seed = seed;
@@ -45,6 +46,7 @@ public class World {
         this.planningNoticeBlocks = new HashSet<>();
         this.dirtyChunks = new HashSet<>();
         this.openDoors = new HashSet<>();
+        this.playerPlacedBlocks = new HashSet<>();
     }
 
     /**
@@ -92,6 +94,36 @@ public class World {
         int localZ = Math.floorMod(z, Chunk.SIZE);
 
         chunk.setBlock(localX, localY, localZ, type);
+    }
+
+    /**
+     * Set a block at world coordinates, recording it as player-placed.
+     * Player-placed blocks are tracked so the council enforcement system can
+     * distinguish between player shelters and world-generated buildings.
+     * If type is AIR, the block is removed from the player-placed set.
+     */
+    public void setPlayerBlock(int x, int y, int z, BlockType type) {
+        setBlock(x, y, z, type);
+        String key = x + "," + y + "," + z;
+        if (type == BlockType.AIR) {
+            playerPlacedBlocks.remove(key);
+        } else {
+            playerPlacedBlocks.add(key);
+        }
+    }
+
+    /**
+     * Check if a block position was placed by the player (not world-generated).
+     */
+    public boolean isPlayerPlaced(int x, int y, int z) {
+        return playerPlacedBlocks.contains(x + "," + y + "," + z);
+    }
+
+    /**
+     * Get the set of all player-placed block positions (as "x,y,z" keys).
+     */
+    public Set<String> getPlayerPlacedBlocks() {
+        return playerPlacedBlocks;
     }
 
     /**

--- a/src/test/java/ragamuffin/integration/BugFix044IntegrationTest.java
+++ b/src/test/java/ragamuffin/integration/BugFix044IntegrationTest.java
@@ -17,8 +17,12 @@ import static org.junit.jupiter.api.Assertions.*;
  * StructureTracker scans BRICK blocks, causing council builders to demolish
  * world-generated buildings.
  *
- * Fix: scanForStructures() and traceStructure() now check for WOOD only,
- * not WOOD || BRICK.
+ * Fix: World tracks player-placed block positions via setPlayerBlock(). Only
+ * blocks recorded as player-placed are considered for structure detection, so
+ * world-generated BRICK buildings are never treated as player structures.
+ * Issue #156 extended detection to all player-placeable materials (BRICK, STONE,
+ * GLASS, CARDBOARD, CONCRETE, etc.) — the player-placed tracking ensures
+ * world-gen buildings with those materials are still excluded.
  */
 class BugFix044IntegrationTest {
 
@@ -83,15 +87,15 @@ class BugFix044IntegrationTest {
 
     /**
      * Integration Test 2: Council builders DO detect player-built WOOD structures.
-     * Place 15 WOOD blocks in a connected cluster at (10, 1, 10). Force scan.
-     * Verify exactly one structure is detected and a COUNCIL_BUILDER has spawned.
+     * Place 15 WOOD blocks (as player-placed) in a connected cluster at (10, 1, 10).
+     * Force scan. Verify exactly one structure is detected and a COUNCIL_BUILDER has spawned.
      */
     @Test
     void playerBuiltWoodStructureTriggersCouncilBuilders() {
-        // Place 15 WOOD blocks in a connected cluster (3x5x1)
+        // Place 15 WOOD blocks in a connected cluster (3x5x1) as player-placed
         for (int x = 10; x < 13; x++) {
             for (int y = 1; y < 6; y++) {
-                world.setBlock(x, y, 10, BlockType.WOOD);
+                world.setPlayerBlock(x, y, 10, BlockType.WOOD);
             }
         }
         // That's 3*5 = 15 WOOD blocks — above the 10-block threshold

--- a/src/test/java/ragamuffin/integration/Issue108AllotmentsFenceTest.java
+++ b/src/test/java/ragamuffin/integration/Issue108AllotmentsFenceTest.java
@@ -82,9 +82,10 @@ class Issue108AllotmentsFenceTest {
     @Test
     void playerBuiltWoodStructureStillTriggersCouncilBuilders() {
         // Place 15 WOOD blocks in a connected cluster (3x5x1), far from allotments
+        // Use setPlayerBlock() to mark them as player-placed
         for (int x = 10; x < 13; x++) {
             for (int y = 1; y < 6; y++) {
-                world.setBlock(x, y, 10, BlockType.WOOD);
+                world.setPlayerBlock(x, y, 10, BlockType.WOOD);
             }
         }
         // That's 3*5 = 15 WOOD blocks — above the 10-block threshold

--- a/src/test/java/ragamuffin/integration/Phase7IntegrationTest.java
+++ b/src/test/java/ragamuffin/integration/Phase7IntegrationTest.java
@@ -56,7 +56,7 @@ class Phase7IntegrationTest {
         for (int x = 10; x < 12; x++) {
             for (int y = 1; y < 3; y++) {
                 for (int z = 10; z < 12; z++) {
-                    world.setBlock(x, y, z, BlockType.WOOD);
+                    world.setPlayerBlock(x, y, z, BlockType.WOOD);
                 }
             }
         }
@@ -107,7 +107,7 @@ class Phase7IntegrationTest {
         for (int x = 20; x < 25; x++) {
             for (int y = 1; y < 6; y++) {
                 for (int z = 20; z < 25; z++) {
-                    world.setBlock(x, y, z, BlockType.WOOD);
+                    world.setPlayerBlock(x, y, z, BlockType.WOOD);
                 }
             }
         }
@@ -184,7 +184,7 @@ class Phase7IntegrationTest {
         for (int x = 30; x < 35; x++) {
             for (int y = 1; y < 6; y++) {
                 for (int z = 30; z < 35; z++) {
-                    world.setBlock(x, y, z, BlockType.WOOD);
+                    world.setPlayerBlock(x, y, z, BlockType.WOOD);
                 }
             }
         }
@@ -260,7 +260,7 @@ class Phase7IntegrationTest {
         for (int x = 40; x < 45; x++) {
             for (int y = 1; y < 6; y++) {
                 for (int z = 40; z < 45; z++) {
-                    world.setBlock(x, y, z, BlockType.WOOD);
+                    world.setPlayerBlock(x, y, z, BlockType.WOOD);
                 }
             }
         }
@@ -348,7 +348,7 @@ class Phase7IntegrationTest {
         for (int x = 50; x < 55; x++) {
             for (int y = 1; y < 6; y++) {
                 for (int z = 50; z < 55; z++) {
-                    world.setBlock(x, y, z, BlockType.WOOD);
+                    world.setPlayerBlock(x, y, z, BlockType.WOOD);
                 }
             }
         }
@@ -372,7 +372,7 @@ class Phase7IntegrationTest {
         for (int x = 60; x < 70; x++) {
             for (int y = 1; y < 6; y++) {
                 for (int z = 60; z < 65; z++) {
-                    world.setBlock(x, y, z, BlockType.WOOD);
+                    world.setPlayerBlock(x, y, z, BlockType.WOOD);
                 }
             }
         }
@@ -411,7 +411,7 @@ class Phase7IntegrationTest {
         for (int x = 70; x < 75; x++) {
             for (int y = 1; y < 6; y++) {
                 for (int z = 70; z < 75; z++) {
-                    world.setBlock(x, y, z, BlockType.WOOD);
+                    world.setPlayerBlock(x, y, z, BlockType.WOOD);
                 }
             }
         }
@@ -461,7 +461,7 @@ class Phase7IntegrationTest {
         for (int x = 10; x < 15; x++) {
             for (int y = 1; y < 6; y++) {
                 for (int z = 10; z < 15; z++) {
-                    world.setBlock(x, y, z, BlockType.WOOD);
+                    world.setPlayerBlock(x, y, z, BlockType.WOOD);
                 }
             }
         }
@@ -551,7 +551,7 @@ class Phase7IntegrationTest {
         for (int x = 60; x < 65; x++) {
             for (int y = 1; y < 6; y++) {
                 for (int z = 60; z < 65; z++) {
-                    world.setBlock(x, y, z, BlockType.WOOD);
+                    world.setPlayerBlock(x, y, z, BlockType.WOOD);
                 }
             }
         }


### PR DESCRIPTION
## Summary
Automated fix for issue #156.

## Changes
- Fix #156: automated fix

Closes #156