### PR TITLE
Fix #168: Police tape only applied to WOOD blocks — BRICK/STONE/GLASS/CARDBOARD structures never taped

### DIFF
--- a/src/main/java/ragamuffin/ai/NPCManager.java
+++ b/src/main/java/ragamuffin/ai/NPCManager.java
@@ -1731,7 +1731,9 @@ public class NPCManager {
                     int z = (int) structureCenter.z + dz;
 
                     BlockType block = world.getBlock(x, y, z);
-                    if (block == BlockType.WOOD) {
+                    if (block == BlockType.WOOD || block == BlockType.BRICK
+                        || block == BlockType.STONE || block == BlockType.GLASS
+                        || block == BlockType.CARDBOARD) {
                         world.addPoliceTape(x, y, z);
                         tapedCount++;
                     }
@@ -1937,5 +1939,12 @@ public class NPCManager {
     public void forceStructureScan(World world, TooltipSystem tooltipSystem) {
         structureTracker.scanForStructures(world);
         updateCouncilBuilders(world, tooltipSystem);
+    }
+
+    /**
+     * Force police tape to be applied to a structure at the given center (for testing).
+     */
+    public void forceApplyPoliceTape(World world, Vector3 structureCenter) {
+        applyPoliceTapeToStructure(world, structureCenter);
     }
 }

--- a/src/test/java/ragamuffin/ai/NPCManagerStructureTest.java
+++ b/src/test/java/ragamuffin/ai/NPCManagerStructureTest.java
@@ -1,5 +1,6 @@
 package ragamuffin.ai;
 
+import com.badlogic.gdx.math.Vector3;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import ragamuffin.building.Inventory;
@@ -130,5 +131,32 @@ class NPCManagerStructureTest {
         assertTrue(builderCount <= 5,
                 "Council builder count should not grow unboundedly — found " + builderCount +
                 " builders after 5 scan cycles (suggests infinite spawning, bug #145 not fixed)");
+    }
+
+    /**
+     * Regression test for Issue #168: applyPoliceTapeToStructure previously only taped
+     * WOOD blocks. BRICK (and other player-placed materials) must also receive police tape.
+     */
+    @Test
+    void testIssue168_applyPoliceTapeToBrickStructure() {
+        // Build a 5-block BRICK structure
+        int cx = 20, cy = 1, cz = 20;
+        for (int i = 0; i < 5; i++) {
+            world.setBlock(cx + i, cy, cz, BlockType.BRICK);
+        }
+
+        // Trigger applyPoliceTapeToStructure via the test helper, centered on the structure
+        npcManager.forceApplyPoliceTape(world, new Vector3(cx + 2, cy, cz));
+
+        // At least one BRICK block must now have police tape
+        boolean tapeFound = false;
+        for (int i = 0; i < 5; i++) {
+            if (world.hasPoliceTape(cx + i, cy, cz)) {
+                tapeFound = true;
+                break;
+            }
+        }
+        assertTrue(tapeFound,
+                "Police tape should be applied to at least one BRICK block (issue #168 not fixed)");
     }
 }


### PR DESCRIPTION
## Summary
Automated fix for issue #168.

## Changes
- Fix #168: expand block-type check in applyPoliceTapeToStructure to include all placeable materials

Closes #168