### PR TITLE
Fix #182: Block hit counts never decay — partially-damaged blocks stay damaged forever

### DIFF
--- a/src/main/java/ragamuffin/core/RagamuffinGame.java
+++ b/src/main/java/ragamuffin/core/RagamuffinGame.java
@@ -880,6 +880,9 @@ public class RagamuffinGame extends ApplicationAdapter {
     }
 
     private void updatePlaying(float delta) {
+        // Decay partially-damaged blocks that have not been hit recently
+        blockBreaker.tickDecay(delta);
+
         // Update first-person arm animation
         firstPersonArm.update(delta);
 


### PR DESCRIPTION
## Summary
Automated fix for issue #182.

## Changes
- Fix #182: add time-based hit decay to BlockBreaker

Closes #182