### PR TITLE
Fix #184: Player AABB not updated after teleport (respawn/arrest)

### DIFF
--- a/src/main/java/ragamuffin/core/ArrestSystem.java
+++ b/src/main/java/ragamuffin/core/ArrestSystem.java
@@ -66,8 +66,10 @@ public class ArrestSystem {
         player.setHealth(HEALTH_AFTER_ARREST);
         player.setHunger(HUNGER_AFTER_ARREST);
 
-        // Dumped back at the park using terrain-aware Y to avoid spawning inside solid blocks
-        player.getPosition().set(ARREST_RESPAWN.x, respawnY, ARREST_RESPAWN.z);
+        // Dumped back at the park using terrain-aware Y to avoid spawning inside solid blocks.
+        // Use teleport() to atomically sync the AABB to the new position so collision
+        // detection is correct on the very first frame after arrest (fixes #184).
+        player.teleport(ARREST_RESPAWN.x, respawnY, ARREST_RESPAWN.z);
         player.setVerticalVelocity(0f);
 
         return confiscated;

--- a/src/main/java/ragamuffin/core/RespawnSystem.java
+++ b/src/main/java/ragamuffin/core/RespawnSystem.java
@@ -77,8 +77,10 @@ public class RespawnSystem {
      * Inventory is preserved.
      */
     private void performRespawn(Player player) {
-        // Respawn at park centre using terrain-aware Y to avoid spawning inside solid blocks
-        player.getPosition().set(PARK_CENTRE.x, spawnY, PARK_CENTRE.z);
+        // Respawn at park centre using terrain-aware Y to avoid spawning inside solid blocks.
+        // Use teleport() to atomically sync the AABB to the new position so collision
+        // detection is correct on the very first frame after respawn (fixes #184).
+        player.teleport(PARK_CENTRE.x, spawnY, PARK_CENTRE.z);
         player.setVerticalVelocity(0f);
 
         // Restore stats and revive

--- a/src/main/java/ragamuffin/entity/Player.java
+++ b/src/main/java/ragamuffin/entity/Player.java
@@ -452,6 +452,19 @@ public class Player {
     }
 
     /**
+     * Teleport the player to the given position, atomically updating both the
+     * position vector and the AABB so collision detection is correct immediately.
+     *
+     * @param x new X coordinate
+     * @param y new Y coordinate
+     * @param z new Z coordinate
+     */
+    public void teleport(float x, float y, float z) {
+        position.set(x, y, z);
+        aabb.setPosition(position, WIDTH, HEIGHT, DEPTH);
+    }
+
+    /**
      * Get the player's street reputation.
      */
     public StreetReputation getStreetReputation() {


### PR DESCRIPTION
## Summary
Automated fix for issue #184.

## Changes
- Fix #184: add Player.teleport() and sync AABB on respawn/arrest

Closes #184