### PR TITLE
Fix #200: Fix E key interaction firing while UI overlays are open

### DIFF
--- a/src/main/java/ragamuffin/core/RagamuffinGame.java
+++ b/src/main/java/ragamuffin/core/RagamuffinGame.java
@@ -810,9 +810,11 @@ public class RagamuffinGame extends ApplicationAdapter {
             inputHandler.resetHotbarSlot();
         }
 
-        // Phase 11: E key interaction
+        // Phase 11: E key interaction — only when no UI overlay is open
         if (inputHandler.isInteractPressed()) {
-            handleInteraction();
+            if (!isUIBlocking()) {
+                handleInteraction();
+            }
             inputHandler.resetInteract();
         }
 


### PR DESCRIPTION
## Summary
Automated fix for issue #200.

## Changes
- Fix #200: guard E key interaction behind isUIBlocking() check

Closes #200