### PR TITLE
Fix #202: Gravity stops when UI overlay is open — player floats mid-air

### DIFF
--- a/src/main/java/ragamuffin/core/RagamuffinGame.java
+++ b/src/main/java/ragamuffin/core/RagamuffinGame.java
@@ -900,6 +900,10 @@ public class RagamuffinGame extends ApplicationAdapter {
      * loading must not freeze when the player has a UI overlay (inventory/crafting/help) open.
      */
     private void updatePlayingSimulation(float delta) {
+        // Fix #202: Apply gravity and vertical collision unconditionally so the player
+        // does not float mid-air when a UI overlay (inventory/help/crafting) is open.
+        world.applyGravityAndVerticalCollision(player, delta);
+
         // Decay partially-damaged blocks that have not been hit recently
         blockBreaker.tickDecay(delta);
 


### PR DESCRIPTION
## Summary
Automated fix for issue #202.

## Changes
- Fix #202: apply gravity unconditionally regardless of UI overlay state

Closes #202