### PR TITLE
Fix #251: LEAVES blocks drop nothing when broken — should yield organic material

### DIFF
--- a/src/main/java/ragamuffin/building/BlockDropTable.java
+++ b/src/main/java/ragamuffin/building/BlockDropTable.java
@@ -105,9 +105,10 @@ public class BlockDropTable {
                 return Material.SIGN_YELLOW;
             case GARDEN_WALL:
                 return Material.GARDEN_WALL;
+            case LEAVES:
+                return (Math.random() < 0.3) ? Material.WOOD : null;
             case AIR:
             case WATER:
-            case LEAVES:
             default:
                 return null; // No drop
         }

--- a/src/test/java/ragamuffin/building/BlockDropTableTest.java
+++ b/src/test/java/ragamuffin/building/BlockDropTableTest.java
@@ -71,9 +71,21 @@ class BlockDropTableTest {
     }
 
     @Test
-    void testLeavesDropNothing() {
-        Material drop = dropTable.getDrop(BlockType.LEAVES, null);
-        assertNull(drop); // Leaves don't drop items
+    void testLeavesDropWoodOrNothing() {
+        // LEAVES have a 30% chance to drop WOOD (twigs/branches); run enough trials
+        // to ensure the result is always either WOOD or null, never anything else.
+        boolean sawWood = false;
+        boolean sawNull = false;
+        for (int i = 0; i < 200; i++) {
+            Material drop = dropTable.getDrop(BlockType.LEAVES, null);
+            assertTrue(drop == null || drop == Material.WOOD,
+                    "LEAVES should drop WOOD or null, but got: " + drop);
+            if (drop == Material.WOOD) sawWood = true;
+            if (drop == null) sawNull = true;
+        }
+        // With 200 trials and 30% probability, the chance of never seeing WOOD is ~1e-31
+        assertTrue(sawWood, "LEAVES should occasionally drop WOOD");
+        assertTrue(sawNull, "LEAVES should sometimes drop nothing");
     }
 
     @Test


### PR DESCRIPTION
## Summary
Automated fix for issue #251.

## Changes
- Fix #251: LEAVES blocks now drop WOOD with 30% probability

Closes #251