### PR TITLE
Fix #255: Placed doors cannot be broken — DOOR_LOWER and DOOR_UPPER are non-solid so punchBlock rejects them

### DIFF
--- a/src/main/java/ragamuffin/building/BlockBreaker.java
+++ b/src/main/java/ragamuffin/building/BlockBreaker.java
@@ -68,6 +68,8 @@ public class BlockBreaker {
             case PAVEMENT:
                 return 8; // hard blocks
             case GLASS:
+            case DOOR_LOWER:
+            case DOOR_UPPER:
                 return 2; // fragile blocks
             default:
                 return 5; // default
@@ -99,8 +101,10 @@ public class BlockBreaker {
     public boolean punchBlock(World world, int x, int y, int z, Material tool) {
         BlockType blockType = world.getBlock(x, y, z);
 
-        // Can't punch air or bedrock, or police-taped (protected) blocks
-        if (blockType == BlockType.AIR || !blockType.isSolid() || blockType == BlockType.BEDROCK
+        // Can't punch air or bedrock, or police-taped (protected) blocks.
+        // DOOR_LOWER and DOOR_UPPER are non-solid (passable) but must still be breakable.
+        boolean isDoorBlock = blockType == BlockType.DOOR_LOWER || blockType == BlockType.DOOR_UPPER;
+        if (blockType == BlockType.AIR || (!blockType.isSolid() && !isDoorBlock) || blockType == BlockType.BEDROCK
                 || world.isProtected(x, y, z)) {
             return false;
         }

--- a/src/main/java/ragamuffin/building/BlockDropTable.java
+++ b/src/main/java/ragamuffin/building/BlockDropTable.java
@@ -67,6 +67,8 @@ public class BlockDropTable {
             case PEBBLEDASH:
                 return Material.PEBBLEDASH;
             case DOOR_WOOD:
+            case DOOR_LOWER:
+            case DOOR_UPPER:
                 return Material.DOOR;
             case LINOLEUM:
                 return Material.LINOLEUM;

--- a/src/test/java/ragamuffin/building/BlockBreakerTest.java
+++ b/src/test/java/ragamuffin/building/BlockBreakerTest.java
@@ -212,6 +212,46 @@ class BlockBreakerTest {
         assertEquals(1, blockBreaker.getHitCount(0, 1, 0));
     }
 
+    // --- Issue #255: Door block breaking tests ---
+
+    @Test
+    void testPunchDoorLower_BreaksAfter2HitsAndDropsDoor() {
+        world.setBlock(0, 1, 0, BlockType.DOOR_LOWER);
+        BlockDropTable dropTable = new BlockDropTable();
+
+        // First punch — should not break
+        boolean broken = blockBreaker.punchBlock(world, 0, 1, 0);
+        assertFalse(broken, "DOOR_LOWER should not break on first punch");
+        assertEquals(BlockType.DOOR_LOWER, world.getBlock(0, 1, 0));
+        assertEquals(1, blockBreaker.getHitCount(0, 1, 0));
+
+        // Second punch — should break
+        broken = blockBreaker.punchBlock(world, 0, 1, 0);
+        assertTrue(broken, "DOOR_LOWER should break on second punch");
+        assertEquals(BlockType.AIR, world.getBlock(0, 1, 0));
+        assertEquals(0, blockBreaker.getHitCount(0, 1, 0));
+
+        // Verify drop
+        Material drop = dropTable.getDrop(BlockType.DOOR_LOWER, null);
+        assertEquals(Material.DOOR, drop, "Breaking DOOR_LOWER should yield Material.DOOR");
+    }
+
+    @Test
+    void testPunchDoorUpper_BreaksAfter2Hits() {
+        world.setBlock(0, 2, 0, BlockType.DOOR_UPPER);
+
+        assertFalse(blockBreaker.punchBlock(world, 0, 2, 0));
+        assertTrue(blockBreaker.punchBlock(world, 0, 2, 0));
+        assertEquals(BlockType.AIR, world.getBlock(0, 2, 0));
+    }
+
+    @Test
+    void testDoorUpper_DropsDoor() {
+        BlockDropTable dropTable = new BlockDropTable();
+        Material drop = dropTable.getDrop(BlockType.DOOR_UPPER, null);
+        assertEquals(Material.DOOR, drop, "Breaking DOOR_UPPER should yield Material.DOOR");
+    }
+
     @Test
     void testTickDecay_OnlyRemovesStaleEntries() throws Exception {
         world.setBlock(0, 1, 0, BlockType.TREE_TRUNK);


### PR DESCRIPTION
## Summary
Automated fix for issue #255.

## Changes
- Fix #255: DOOR_LOWER and DOOR_UPPER blocks can now be broken by punching

Closes #255