### PR TITLE
Fix #263: ANTIDEPRESSANTS item consumed silently with no effect or feedback

### DIFF
--- a/src/main/java/ragamuffin/core/InteractionSystem.java
+++ b/src/main/java/ragamuffin/core/InteractionSystem.java
@@ -148,6 +148,7 @@ public class InteractionSystem {
             return false;
         }
 
+        lastConsumeMessage = null;
         float hungerRestored = 0;
 
         if (food == Material.SAUSAGE_ROLL) {
@@ -192,7 +193,8 @@ public class InteractionSystem {
             return true; // Already removed, skip the removal below
         } else if (food == Material.ANTIDEPRESSANTS) {
             hungerRestored = 0;
-            // Inert item - nothing happens when consumed
+            player.restoreEnergy(20); // Steadies the nerves
+            lastConsumeMessage = "You take one. Does anything feel different? Hard to say.";
         } else {
             // Not a consumable item
             return false;
@@ -211,10 +213,24 @@ public class InteractionSystem {
     private boolean lastScratchCardWon = false;
 
     /**
+     * Optional tooltip message set by the last consumeFood() call.
+     * May be null if no message was generated.
+     */
+    private String lastConsumeMessage = null;
+
+    /**
      * Check if the last scratch card was a winner.
      */
     public boolean didLastScratchCardWin() {
         return lastScratchCardWon;
+    }
+
+    /**
+     * Get the tooltip message set by the last consumeFood() call, if any.
+     * Returns null if no message was generated.
+     */
+    public String getLastConsumeMessage() {
+        return lastConsumeMessage;
     }
 
     /**

--- a/src/main/java/ragamuffin/core/RagamuffinGame.java
+++ b/src/main/java/ragamuffin/core/RagamuffinGame.java
@@ -1331,7 +1331,11 @@ public class RagamuffinGame extends ApplicationAdapter {
         if (interactionSystem.isFood(material)) {
             boolean consumed = interactionSystem.consumeFood(material, player, inventory);
             if (consumed) {
-                // Food was eaten successfully
+                // Show any feedback message from the consumable
+                String consumeMsg = interactionSystem.getLastConsumeMessage();
+                if (consumeMsg != null) {
+                    tooltipSystem.showMessage(consumeMsg, 3.0f);
+                }
                 return;
             }
         }

--- a/src/test/java/ragamuffin/integration/ConsumablesAndCraftingIntegrationTest.java
+++ b/src/test/java/ragamuffin/integration/ConsumablesAndCraftingIntegrationTest.java
@@ -104,10 +104,11 @@ class ConsumablesAndCraftingIntegrationTest {
     }
 
     @Test
-    void testConsumeAntidepressantsDoesNothing() {
-        // Set up player with low health and hunger
+    void testConsumeAntidepressantsRestoresEnergyAndShowsMessage() {
+        // Set up player with low stats to verify effects
         player.setHealth(50);
         player.setHunger(50);
+        player.setEnergy(50);
         float energyBefore = player.getEnergy();
         inventory.addItem(Material.ANTIDEPRESSANTS, 1);
 
@@ -117,13 +118,19 @@ class ConsumablesAndCraftingIntegrationTest {
         // Verify item was consumed
         assertEquals(0, inventory.getItemCount(Material.ANTIDEPRESSANTS),
             "ANTIDEPRESSANTS should be removed from inventory");
-        // Verify no effects (inert item)
+        // Verify no health or hunger effect
         assertEquals(50, player.getHealth(), 0.01,
             "ANTIDEPRESSANTS should not affect health");
         assertEquals(50, player.getHunger(), 0.01,
             "ANTIDEPRESSANTS should not affect hunger");
-        assertEquals(energyBefore, player.getEnergy(), 0.01,
-            "ANTIDEPRESSANTS should not affect energy");
+        // Verify energy is restored (meaningful gameplay effect)
+        assertTrue(player.getEnergy() > energyBefore,
+            "ANTIDEPRESSANTS should restore energy");
+        // Verify a flavour message is set
+        assertNotNull(interactionSystem.getLastConsumeMessage(),
+            "ANTIDEPRESSANTS should produce a feedback message");
+        assertFalse(interactionSystem.getLastConsumeMessage().isEmpty(),
+            "ANTIDEPRESSANTS feedback message should not be empty");
     }
 
     // === New crafting recipes ===

--- a/src/test/java/ragamuffin/integration/Issue263AntidepressantsTest.java
+++ b/src/test/java/ragamuffin/integration/Issue263AntidepressantsTest.java
@@ -1,0 +1,98 @@
+package ragamuffin.integration;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import ragamuffin.building.Inventory;
+import ragamuffin.building.Material;
+import ragamuffin.core.InteractionSystem;
+import ragamuffin.entity.Player;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Integration tests for Issue #263: ANTIDEPRESSANTS item consumed silently with no effect or feedback.
+ *
+ * Verifies that ANTIDEPRESSANTS:
+ * 1. Restores energy when consumed (meaningful gameplay effect)
+ * 2. Produces a flavour feedback message via getLastConsumeMessage()
+ * 3. Is removed from inventory on use
+ * 4. Does not affect health or hunger
+ */
+class Issue263AntidepressantsTest {
+
+    private Player player;
+    private Inventory inventory;
+    private InteractionSystem interactionSystem;
+
+    @BeforeEach
+    void setUp() {
+        player = new Player(0, 1, 0);
+        inventory = new Inventory(36);
+        interactionSystem = new InteractionSystem();
+    }
+
+    @Test
+    void testAntidepressantsRestoresEnergy() {
+        // Drain energy so there is headroom to restore
+        player.setEnergy(50);
+        inventory.addItem(Material.ANTIDEPRESSANTS, 1);
+
+        interactionSystem.consumeFood(Material.ANTIDEPRESSANTS, player, inventory);
+
+        assertTrue(player.getEnergy() > 50,
+            "ANTIDEPRESSANTS should restore some energy when consumed");
+    }
+
+    @Test
+    void testAntidepressantsShowsFeedbackMessage() {
+        inventory.addItem(Material.ANTIDEPRESSANTS, 1);
+
+        boolean consumed = interactionSystem.consumeFood(Material.ANTIDEPRESSANTS, player, inventory);
+
+        assertTrue(consumed, "ANTIDEPRESSANTS should be consumed");
+        String message = interactionSystem.getLastConsumeMessage();
+        assertNotNull(message,
+            "ANTIDEPRESSANTS should produce a feedback message after consumption");
+        assertFalse(message.trim().isEmpty(),
+            "ANTIDEPRESSANTS feedback message should not be blank");
+    }
+
+    @Test
+    void testAntidepressantsRemovedFromInventoryOnUse() {
+        inventory.addItem(Material.ANTIDEPRESSANTS, 1);
+        assertEquals(1, inventory.getItemCount(Material.ANTIDEPRESSANTS));
+
+        interactionSystem.consumeFood(Material.ANTIDEPRESSANTS, player, inventory);
+
+        assertEquals(0, inventory.getItemCount(Material.ANTIDEPRESSANTS),
+            "ANTIDEPRESSANTS should be removed from inventory on use");
+    }
+
+    @Test
+    void testAntidepressantsDoesNotAffectHealthOrHunger() {
+        player.setHealth(60);
+        player.setHunger(40);
+        inventory.addItem(Material.ANTIDEPRESSANTS, 1);
+
+        interactionSystem.consumeFood(Material.ANTIDEPRESSANTS, player, inventory);
+
+        assertEquals(60, player.getHealth(), 0.01,
+            "ANTIDEPRESSANTS should not change health");
+        assertEquals(40, player.getHunger(), 0.01,
+            "ANTIDEPRESSANTS should not change hunger");
+    }
+
+    @Test
+    void testLastConsumeMessageClearedOnNewConsumption() {
+        // Consume antidepressants first to set the message
+        inventory.addItem(Material.ANTIDEPRESSANTS, 1);
+        interactionSystem.consumeFood(Material.ANTIDEPRESSANTS, player, inventory);
+        assertNotNull(interactionSystem.getLastConsumeMessage());
+
+        // Consume a regular food item — message should be cleared (null for items with no message)
+        inventory.addItem(Material.SAUSAGE_ROLL, 1);
+        interactionSystem.consumeFood(Material.SAUSAGE_ROLL, player, inventory);
+        assertNull(interactionSystem.getLastConsumeMessage(),
+            "lastConsumeMessage should be null after consuming an item that sets no message");
+    }
+}


### PR DESCRIPTION
## Summary
Automated fix for issue #263.

## Changes
- Fix #263: ANTIDEPRESSANTS now restores energy and shows feedback message

Closes #263