### PR TITLE
Fix #267: Scratch card gives no win/loss feedback when used

### DIFF
--- a/src/main/java/ragamuffin/core/InteractionSystem.java
+++ b/src/main/java/ragamuffin/core/InteractionSystem.java
@@ -187,8 +187,10 @@ public class InteractionSystem {
             if (RANDOM.nextInt(5) == 0) {
                 inventory.addItem(Material.DIAMOND, 1);
                 lastScratchCardWon = true;
+                lastConsumeMessage = "You scratch the card. YOU HAVE WON! A diamond falls out.";
             } else {
                 lastScratchCardWon = false;
+                lastConsumeMessage = "You scratch the card. Not a winner. Gutted.";
             }
             return true; // Already removed, skip the removal below
         } else if (food == Material.ANTIDEPRESSANTS) {


### PR DESCRIPTION
## Summary
Automated fix for issue #267.

## Changes
- Fix #267: Scratch card now sets win/loss feedback message in consumeFood()

Closes #267