### PR TITLE
Fix #271: Food consumption gives no feedback message for most consumables

### DIFF
--- a/src/main/java/ragamuffin/core/InteractionSystem.java
+++ b/src/main/java/ragamuffin/core/InteractionSystem.java
@@ -153,33 +153,45 @@ public class InteractionSystem {
 
         if (food == Material.SAUSAGE_ROLL) {
             hungerRestored = 30;
+            lastConsumeMessage = "You eat the sausage roll. Warm, flaky, perfect.";
         } else if (food == Material.STEAK_BAKE) {
             hungerRestored = 35;
+            lastConsumeMessage = "You wolf down the steak bake. Greggs delivers again.";
         } else if (food == Material.CHIPS) {
             hungerRestored = 25;
+            lastConsumeMessage = "You eat the chips. Slightly soggy, but beggars can't be choosers.";
         } else if (food == Material.KEBAB) {
             hungerRestored = 40;
+            lastConsumeMessage = "You demolish the kebab. Mysterious meat, no questions asked.";
         } else if (food == Material.CRISPS) {
             hungerRestored = 10;
+            lastConsumeMessage = "You crunch through the crisps. Ready salted. Classic.";
         } else if (food == Material.TIN_OF_BEANS) {
             hungerRestored = 35;
+            lastConsumeMessage = "You eat the beans cold from the tin. Desperate times.";
         } else if (food == Material.ENERGY_DRINK) {
             hungerRestored = 5;
             player.restoreEnergy(30); // Energy drink restores energy too
+            lastConsumeMessage = "You neck the energy drink. Your heart is now vibrating.";
         } else if (food == Material.PINT) {
             hungerRestored = 15;
             player.restoreEnergy(20); // Liquid courage
+            lastConsumeMessage = "You down the pint. Dutch courage, British problems.";
         } else if (food == Material.PERI_PERI_CHICKEN) {
             hungerRestored = 45; // Cheeky Nandos is top-tier sustenance
+            lastConsumeMessage = "Cheeky Nandos. Even out here, it hits different.";
         } else if (food == Material.PARACETAMOL) {
             hungerRestored = 0;
             player.heal(25); // Direct health restoration
+            lastConsumeMessage = "You take two paracetamol. That should help.";
         } else if (food == Material.FIRE_EXTINGUISHER) {
             hungerRestored = 0;
             player.heal(20); // Blast of cold foam soothes the wounds
+            lastConsumeMessage = "You blast yourself with foam. Oddly soothing.";
         } else if (food == Material.WASHING_POWDER) {
             hungerRestored = 0;
             player.restoreEnergy(15); // Clean laundry scent is invigorating
+            lastConsumeMessage = "You sniff the washing powder. Invigorating.";
         } else if (food == Material.SCRATCH_CARD) {
             hungerRestored = 0;
             inventory.removeItem(food, 1);

--- a/src/test/java/ragamuffin/integration/Issue263AntidepressantsTest.java
+++ b/src/test/java/ragamuffin/integration/Issue263AntidepressantsTest.java
@@ -87,12 +87,16 @@ class Issue263AntidepressantsTest {
         // Consume antidepressants first to set the message
         inventory.addItem(Material.ANTIDEPRESSANTS, 1);
         interactionSystem.consumeFood(Material.ANTIDEPRESSANTS, player, inventory);
-        assertNotNull(interactionSystem.getLastConsumeMessage());
+        String antidepressantsMsg = interactionSystem.getLastConsumeMessage();
+        assertNotNull(antidepressantsMsg);
 
-        // Consume a regular food item — message should be cleared (null for items with no message)
+        // Consume another food item — each consumable now sets its own distinct message
         inventory.addItem(Material.SAUSAGE_ROLL, 1);
         interactionSystem.consumeFood(Material.SAUSAGE_ROLL, player, inventory);
-        assertNull(interactionSystem.getLastConsumeMessage(),
-            "lastConsumeMessage should be null after consuming an item that sets no message");
+        String sausageRollMsg = interactionSystem.getLastConsumeMessage();
+        assertNotNull(sausageRollMsg,
+            "lastConsumeMessage should be set after consuming SAUSAGE_ROLL (Issue #271 fix)");
+        assertNotEquals(antidepressantsMsg, sausageRollMsg,
+            "Each consumable should have its own distinct feedback message");
     }
 }

--- a/src/test/java/ragamuffin/integration/Issue271FoodFeedbackMessageTest.java
+++ b/src/test/java/ragamuffin/integration/Issue271FoodFeedbackMessageTest.java
@@ -1,0 +1,129 @@
+package ragamuffin.integration;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import ragamuffin.building.Inventory;
+import ragamuffin.building.Material;
+import ragamuffin.core.InteractionSystem;
+import ragamuffin.entity.Player;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Integration tests for Issue #271: Food consumption must always set a feedback
+ * message via lastConsumeMessage so the tooltip system can display it.
+ */
+class Issue271FoodFeedbackMessageTest {
+
+    private Player player;
+    private Inventory inventory;
+    private InteractionSystem interactionSystem;
+
+    @BeforeEach
+    void setUp() {
+        player = new Player(0, 1, 0);
+        inventory = new Inventory(36);
+        interactionSystem = new InteractionSystem();
+    }
+
+    private void assertFeedbackMessage(Material food) {
+        inventory.addItem(food, 1);
+        boolean consumed = interactionSystem.consumeFood(food, player, inventory);
+        assertTrue(consumed, food + " should be consumed successfully");
+        String msg = interactionSystem.getLastConsumeMessage();
+        assertNotNull(msg, food + " should produce a non-null feedback message");
+        assertFalse(msg.isEmpty(), food + " feedback message should not be empty");
+    }
+
+    @Test
+    void testSausageRollSetsFeedbackMessage() {
+        assertFeedbackMessage(Material.SAUSAGE_ROLL);
+    }
+
+    @Test
+    void testSteakBakeSetsFeedbackMessage() {
+        assertFeedbackMessage(Material.STEAK_BAKE);
+    }
+
+    @Test
+    void testChipsSetsFeedbackMessage() {
+        assertFeedbackMessage(Material.CHIPS);
+    }
+
+    @Test
+    void testKebabSetsFeedbackMessage() {
+        assertFeedbackMessage(Material.KEBAB);
+    }
+
+    @Test
+    void testCrispsSetsFeedbackMessage() {
+        assertFeedbackMessage(Material.CRISPS);
+    }
+
+    @Test
+    void testTinOfBeansSetsFeedbackMessage() {
+        assertFeedbackMessage(Material.TIN_OF_BEANS);
+    }
+
+    @Test
+    void testEnergyDrinkSetsFeedbackMessage() {
+        assertFeedbackMessage(Material.ENERGY_DRINK);
+    }
+
+    @Test
+    void testPintSetsFeedbackMessage() {
+        assertFeedbackMessage(Material.PINT);
+    }
+
+    @Test
+    void testPeriPeriChickenSetsFeedbackMessage() {
+        assertFeedbackMessage(Material.PERI_PERI_CHICKEN);
+    }
+
+    @Test
+    void testParacetamolSetsFeedbackMessage() {
+        assertFeedbackMessage(Material.PARACETAMOL);
+    }
+
+    @Test
+    void testFireExtinguisherSetsFeedbackMessage() {
+        assertFeedbackMessage(Material.FIRE_EXTINGUISHER);
+    }
+
+    @Test
+    void testWashingPowderSetsFeedbackMessage() {
+        assertFeedbackMessage(Material.WASHING_POWDER);
+    }
+
+    @Test
+    void testSausageRollMessageContent() {
+        inventory.addItem(Material.SAUSAGE_ROLL, 1);
+        interactionSystem.consumeFood(Material.SAUSAGE_ROLL, player, inventory);
+        assertEquals("You eat the sausage roll. Warm, flaky, perfect.",
+            interactionSystem.getLastConsumeMessage());
+    }
+
+    @Test
+    void testParacetamolMessageContent() {
+        inventory.addItem(Material.PARACETAMOL, 1);
+        interactionSystem.consumeFood(Material.PARACETAMOL, player, inventory);
+        assertEquals("You take two paracetamol. That should help.",
+            interactionSystem.getLastConsumeMessage());
+    }
+
+    @Test
+    void testFireExtinguisherMessageContent() {
+        inventory.addItem(Material.FIRE_EXTINGUISHER, 1);
+        interactionSystem.consumeFood(Material.FIRE_EXTINGUISHER, player, inventory);
+        assertEquals("You blast yourself with foam. Oddly soothing.",
+            interactionSystem.getLastConsumeMessage());
+    }
+
+    @Test
+    void testWashingPowderMessageContent() {
+        inventory.addItem(Material.WASHING_POWDER, 1);
+        interactionSystem.consumeFood(Material.WASHING_POWDER, player, inventory);
+        assertEquals("You sniff the washing powder. Invigorating.",
+            interactionSystem.getLastConsumeMessage());
+    }
+}


### PR DESCRIPTION
## Summary
Automated fix for issue #271.

## Changes
- Fix #271: Set feedback messages for all food/consumable items in consumeFood()

Closes #271