### PR TITLE
Fix #273: Prevent gravity and fall damage from applying to dead player

### DIFF
--- a/src/main/java/ragamuffin/core/RagamuffinGame.java
+++ b/src/main/java/ragamuffin/core/RagamuffinGame.java
@@ -949,7 +949,11 @@ public class RagamuffinGame extends ApplicationAdapter {
     private void updatePlayingSimulation(float delta) {
         // Fix #202: Apply gravity and vertical collision unconditionally so the player
         // does not float mid-air when a UI overlay (inventory/help/crafting) is open.
-        world.applyGravityAndVerticalCollision(player, delta);
+        // Fix #273: Skip gravity/fall-damage when the player is already dead to prevent
+        // damage-flash strobing on the death screen and corpse drift during respawn countdown.
+        if (!player.isDead()) {
+            world.applyGravityAndVerticalCollision(player, delta);
+        }
 
         // Decay partially-damaged blocks that have not been hit recently
         blockBreaker.tickDecay(delta);


### PR DESCRIPTION
## Summary
Automated fix for issue #273.

## Changes
- Fix #273: Skip gravity/fall-damage for dead player in updatePlayingSimulation()

Closes #273