### PR TITLE
Fix #281: NPC speech bubbles render as opaque black boxes — GL_BLEND not enabled

### DIFF
--- a/src/main/java/ragamuffin/core/RagamuffinGame.java
+++ b/src/main/java/ragamuffin/core/RagamuffinGame.java
@@ -1715,10 +1715,13 @@ public class RagamuffinGame extends ApplicationAdapter {
             float bubbleY = sy;
 
             // Draw speech bubble background
+            Gdx.gl.glEnable(GL20.GL_BLEND);
+            Gdx.gl.glBlendFunc(GL20.GL_SRC_ALPHA, GL20.GL_ONE_MINUS_SRC_ALPHA);
             shapeRenderer.begin(com.badlogic.gdx.graphics.glutils.ShapeRenderer.ShapeType.Filled);
             shapeRenderer.setColor(0f, 0f, 0f, 0.7f);
             shapeRenderer.rect(bubbleX, bubbleY, bubbleW, bubbleH);
             shapeRenderer.end();
+            Gdx.gl.glDisable(GL20.GL_BLEND);
 
             // Draw text
             spriteBatch.begin();


### PR DESCRIPTION
## Summary
Automated fix for issue #281.

## Changes
- Fix #281: Enable GL_BLEND for semi-transparent NPC speech bubble backgrounds

Closes #281