### PR TITLE
Fix #291: Non-consumable use items (NEWSPAPER, TEXTBOOK, etc.) never removed from inventory — infinite energy exploit

### DIFF
--- a/src/main/java/ragamuffin/core/InteractionSystem.java
+++ b/src/main/java/ragamuffin/core/InteractionSystem.java
@@ -403,12 +403,15 @@ public class InteractionSystem {
         switch (material) {
             case NEWSPAPER:
                 player.restoreEnergy(5);
+                inventory.removeItem(material, 1);
                 return "You skim the headlines. Grim reading, but oddly soothing.";
             case TEXTBOOK:
                 player.restoreEnergy(8);
+                inventory.removeItem(material, 1);
                 return "Dense prose, no pictures. Your brain hurts slightly less than before.";
             case HYMN_BOOK:
                 player.restoreEnergy(5);
+                inventory.removeItem(material, 1);
                 return "You hum a verse. It doesn't help much, but it's something.";
             case PETROL_CAN:
                 return "Smells like trouble. Useful as a crafting ingredient.";

--- a/src/test/java/ragamuffin/integration/Issue257NonConsumableLootTest.java
+++ b/src/test/java/ragamuffin/integration/Issue257NonConsumableLootTest.java
@@ -147,9 +147,9 @@ class Issue257NonConsumableLootTest {
         assertFalse(message.isEmpty(), "NEWSPAPER tooltip message should not be empty");
         assertTrue(player.getEnergy() > energyBefore,
             "Reading NEWSPAPER should restore some energy");
-        // Item is NOT consumed by useItem (stays in inventory)
-        assertEquals(1, inventory.getItemCount(Material.NEWSPAPER),
-            "NEWSPAPER should NOT be removed from inventory by useItem()");
+        // Item IS consumed by useItem (fix #291)
+        assertEquals(0, inventory.getItemCount(Material.NEWSPAPER),
+            "NEWSPAPER should be removed from inventory by useItem()");
     }
 
     @Test

--- a/src/test/java/ragamuffin/integration/Issue291NonConsumableEnergyExploitTest.java
+++ b/src/test/java/ragamuffin/integration/Issue291NonConsumableEnergyExploitTest.java
@@ -1,0 +1,108 @@
+package ragamuffin.integration;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import ragamuffin.building.Inventory;
+import ragamuffin.building.Material;
+import ragamuffin.core.InteractionSystem;
+import ragamuffin.entity.Player;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Integration tests for Issue #291: Non-consumable use items (NEWSPAPER, TEXTBOOK, HYMN_BOOK)
+ * must be removed from inventory on use to prevent infinite energy exploit.
+ */
+class Issue291NonConsumableEnergyExploitTest {
+
+    private Player player;
+    private Inventory inventory;
+    private InteractionSystem interactionSystem;
+
+    @BeforeEach
+    void setUp() {
+        player = new Player(0, 1, 0);
+        inventory = new Inventory(36);
+        interactionSystem = new InteractionSystem();
+    }
+
+    @Test
+    void testNewspaperIsConsumedOnUse() {
+        inventory.addItem(Material.NEWSPAPER, 1);
+        player.setEnergy(50);
+
+        interactionSystem.useItem(Material.NEWSPAPER, player, inventory);
+
+        assertEquals(0, inventory.getItemCount(Material.NEWSPAPER),
+            "NEWSPAPER should be consumed (removed) from inventory on use");
+    }
+
+    @Test
+    void testTextbookIsConsumedOnUse() {
+        inventory.addItem(Material.TEXTBOOK, 1);
+        player.setEnergy(50);
+
+        interactionSystem.useItem(Material.TEXTBOOK, player, inventory);
+
+        assertEquals(0, inventory.getItemCount(Material.TEXTBOOK),
+            "TEXTBOOK should be consumed (removed) from inventory on use");
+    }
+
+    @Test
+    void testHymnBookIsConsumedOnUse() {
+        inventory.addItem(Material.HYMN_BOOK, 1);
+        player.setEnergy(50);
+
+        interactionSystem.useItem(Material.HYMN_BOOK, player, inventory);
+
+        assertEquals(0, inventory.getItemCount(Material.HYMN_BOOK),
+            "HYMN_BOOK should be consumed (removed) from inventory on use");
+    }
+
+    @Test
+    void testNewspaperCannotBeUsedRepeatedlyWithOneItem() {
+        inventory.addItem(Material.NEWSPAPER, 1);
+        player.setEnergy(0);
+
+        // First use should restore energy and consume the item
+        interactionSystem.useItem(Material.NEWSPAPER, player, inventory);
+        float energyAfterFirst = player.getEnergy();
+        assertTrue(energyAfterFirst > 0, "First NEWSPAPER use should restore energy");
+
+        // Second use with no items left should not restore additional energy
+        player.setEnergy(0);
+        interactionSystem.useItem(Material.NEWSPAPER, player, inventory);
+
+        assertEquals(0, inventory.getItemCount(Material.NEWSPAPER),
+            "No NEWSPAPER remaining after first use");
+    }
+
+    @Test
+    void testNewspaperStackDecrementsByOne() {
+        inventory.addItem(Material.NEWSPAPER, 3);
+        player.setEnergy(50);
+
+        interactionSystem.useItem(Material.NEWSPAPER, player, inventory);
+
+        assertEquals(2, inventory.getItemCount(Material.NEWSPAPER),
+            "Stack of 3 NEWSPAPERs should decrement to 2 after one use");
+    }
+
+    @Test
+    void testFlavourItemsAreNotConsumedOnUse() {
+        // Purely informational items should NOT be consumed
+        Material[] flavourItems = {
+            Material.HAIR_CLIPPERS, Material.NAIL_POLISH, Material.BROKEN_PHONE,
+            Material.DODGY_DVD, Material.PLYWOOD, Material.PIPE,
+            Material.COMPUTER, Material.OFFICE_CHAIR, Material.STAPLER,
+            Material.PETROL_CAN, Material.DIAMOND
+        };
+
+        for (Material m : flavourItems) {
+            inventory.addItem(m, 1);
+            interactionSystem.useItem(m, player, inventory);
+            assertEquals(1, inventory.getItemCount(m),
+                m + " (flavour item) should NOT be consumed from inventory on use");
+        }
+    }
+}


### PR DESCRIPTION
## Summary
Automated fix for issue #291.

## Changes
- Fix #291: Consume NEWSPAPER/TEXTBOOK/HYMN_BOOK from inventory on use

Closes #291