### PR TITLE
Fix #301: Doors are untargetable: raycast skips DOOR_LOWER/DOOR_UPPER blocks

### DIFF
--- a/src/main/java/ragamuffin/world/Raycast.java
+++ b/src/main/java/ragamuffin/world/Raycast.java
@@ -46,9 +46,10 @@ public class Raycast {
 
         // Traverse voxels along the ray
         while (distance < maxDistance) {
-            // Check if current voxel is solid
+            // Check if current voxel is solid or a door block (non-solid but targetable/breakable)
             BlockType block = world.getBlock(x, y, z);
-            if (block != BlockType.AIR && block.isSolid()) {
+            boolean isDoorBlock = block == BlockType.DOOR_LOWER || block == BlockType.DOOR_UPPER;
+            if (block != BlockType.AIR && (block.isSolid() || isDoorBlock)) {
                 Vector3 hitPos = new Vector3(origin).add(new Vector3(dir).scl(distance));
                 return new RaycastResult(x, y, z, block, hitPos, distance);
             }

--- a/src/test/java/ragamuffin/world/RaycastTest.java
+++ b/src/test/java/ragamuffin/world/RaycastTest.java
@@ -121,4 +121,38 @@ class RaycastTest {
         assertEquals(1, result.getBlockY()); // Should hit nearest block first
         assertEquals(BlockType.GRASS, result.getBlockType());
     }
+
+    @Test
+    void testRaycastHitsDoorLower() {
+        World world = new World(12345);
+        world.setBlock(0, 0, 0, BlockType.DOOR_LOWER);
+
+        Vector3 origin = new Vector3(0.5f, 5f, 0.5f);
+        Vector3 direction = new Vector3(0, -1, 0);
+
+        RaycastResult result = Raycast.cast(world, origin, direction, 10f);
+
+        assertNotNull(result, "Raycast should hit DOOR_LOWER even though it is non-solid");
+        assertEquals(0, result.getBlockX());
+        assertEquals(0, result.getBlockY());
+        assertEquals(0, result.getBlockZ());
+        assertEquals(BlockType.DOOR_LOWER, result.getBlockType());
+    }
+
+    @Test
+    void testRaycastHitsDoorUpper() {
+        World world = new World(12345);
+        world.setBlock(0, 1, 0, BlockType.DOOR_UPPER);
+
+        Vector3 origin = new Vector3(0.5f, 5f, 0.5f);
+        Vector3 direction = new Vector3(0, -1, 0);
+
+        RaycastResult result = Raycast.cast(world, origin, direction, 10f);
+
+        assertNotNull(result, "Raycast should hit DOOR_UPPER even though it is non-solid");
+        assertEquals(0, result.getBlockX());
+        assertEquals(1, result.getBlockY());
+        assertEquals(0, result.getBlockZ());
+        assertEquals(BlockType.DOOR_UPPER, result.getBlockType());
+    }
 }


### PR DESCRIPTION
## Summary
Automated fix for issue #301.

## Changes
- Fix #301: Make DOOR_LOWER/DOOR_UPPER targetable by raycast

Closes #301