### PR TITLE
Fix #303: No sound plays when player consumes food or uses items (right-click)

### DIFF
--- a/src/main/java/ragamuffin/audio/SoundEffect.java
+++ b/src/main/java/ragamuffin/audio/SoundEffect.java
@@ -31,5 +31,9 @@ public enum SoundEffect {
 
     // Special events
     POLICE_SIREN,
-    TOOLTIP
+    TOOLTIP,
+
+    // Item use sounds
+    ITEM_EAT,
+    ITEM_USE
 }

--- a/src/main/java/ragamuffin/audio/SoundSystem.java
+++ b/src/main/java/ragamuffin/audio/SoundSystem.java
@@ -167,6 +167,7 @@ public class SoundSystem {
             case UI_OPEN:
             case UI_CLOSE:
             case TOOLTIP:
+            case ITEM_USE:
                 return VOLUME_UI;
             case AMBIENT_PARK:
             case AMBIENT_STREET:

--- a/src/main/java/ragamuffin/core/RagamuffinGame.java
+++ b/src/main/java/ragamuffin/core/RagamuffinGame.java
@@ -1414,6 +1414,7 @@ public class RagamuffinGame extends ApplicationAdapter {
         if (interactionSystem.isFood(material)) {
             boolean consumed = interactionSystem.consumeFood(material, player, inventory);
             if (consumed) {
+                soundSystem.play(ragamuffin.audio.SoundEffect.ITEM_EAT);
                 // Show any feedback message from the consumable
                 String consumeMsg = interactionSystem.getLastConsumeMessage();
                 if (consumeMsg != null) {
@@ -1426,6 +1427,7 @@ public class RagamuffinGame extends ApplicationAdapter {
         // Fix #257: Check if material has a non-food, non-placeable use action
         if (interactionSystem.canUseItem(material)) {
             String message = interactionSystem.useItem(material, player, inventory);
+            soundSystem.play(ragamuffin.audio.SoundEffect.ITEM_USE);
             if (message != null) {
                 tooltipSystem.showMessage(message, 3.0f);
             }


### PR DESCRIPTION
## Summary
Automated fix for issue #303.

## Changes
- Fix #303: Play ITEM_EAT and ITEM_USE sounds on food consumption and item use

Closes #303