### PR TITLE
Fix #309: restartGame() leaks NPCRenderer per-NPC model instances across sessions

### DIFF
--- a/src/main/java/ragamuffin/core/RagamuffinGame.java
+++ b/src/main/java/ragamuffin/core/RagamuffinGame.java
@@ -1844,6 +1844,10 @@ public class RagamuffinGame extends ApplicationAdapter {
         // hit-counter clears work from the start of the restarted game
         blockBreaker = new BlockBreaker();
         blockPlacer.setBlockBreaker(blockBreaker);
+        // Fix #309: Dispose old NPCRenderer to release per-NPC ModelInstance arrays and
+        // native GPU resources (Mesh/Material) before creating new NPCManager/NPCs.
+        npcRenderer.dispose();
+        npcRenderer = new NPCRenderer();
         npcManager = new NPCManager();
         npcManager.setBlockBreaker(blockBreaker);
         spawnInitialNPCs();


### PR DESCRIPTION
## Summary
Automated fix for issue #309.

## Changes
- Fix #309: Dispose and recreate NPCRenderer in restartGame() to prevent resource leak

Closes #309