### PR TITLE
Fix #315: restartGame() ignores Skip Intro setting, always plays opening sequence

### DIFF
--- a/src/main/java/ragamuffin/core/RagamuffinGame.java
+++ b/src/main/java/ragamuffin/core/RagamuffinGame.java
@@ -1918,6 +1918,9 @@ public class RagamuffinGame extends ApplicationAdapter {
         // Transition to playing with opening sequence
         state = GameState.PLAYING;
         openingSequence.start();
+        if (mainMenuScreen.isSkipIntroEnabled()) {
+            openingSequence.skip();
+        }
         Gdx.input.setCursorCatched(true);
     }
 


### PR DESCRIPTION
## Summary
Automated fix for issue #315.

## Changes
- Fix #315: Respect Skip Intro setting in restartGame()

Closes #315