### PR TITLE
Fix #327: restartGame() leaks rainTimer — rain animation continues from previous session state

### DIFF
--- a/src/main/java/ragamuffin/core/RagamuffinGame.java
+++ b/src/main/java/ragamuffin/core/RagamuffinGame.java
@@ -1924,6 +1924,7 @@ public class RagamuffinGame extends ApplicationAdapter {
             particleSystem = new ragamuffin.render.ParticleSystem();
         }
         footstepDustTimer = 0f;
+        rainTimer = 0f;
 
         // Fix #299: Clear sticky punch state so auto-punch doesn't fire in the first frame
         // of the new game session (mirrors the same reset in transitionToPaused() and on death).


### PR DESCRIPTION
## Summary
Automated fix for issue #327.

## Changes
- Fix #327: Reset rainTimer in restartGame() to prevent leaked animation state

Closes #327