### PR TITLE
Fix #331: restartGame() leaks firstPersonArm swing state — arm may be mid-swing at new session start

### DIFF
--- a/src/main/java/ragamuffin/core/RagamuffinGame.java
+++ b/src/main/java/ragamuffin/core/RagamuffinGame.java
@@ -692,6 +692,9 @@ public class RagamuffinGame extends ApplicationAdapter {
             // red vignette fades out and the damage-reason banner counts down.
             player.updateFlash(delta);
             gameHUD.update(delta);
+            // Fix #331: Advance tooltip countdown while paused so active tooltips
+            // fade out and queued tooltips advance rather than freezing on-screen.
+            tooltipSystem.update(delta);
 
             // Render UI and pause menu
             renderUI();
@@ -1936,6 +1939,10 @@ public class RagamuffinGame extends ApplicationAdapter {
         punchHeldTimer = 0f;
         lastPunchTargetKey = null;
         inputHandler.resetPunchHeld();
+        // Fix #331: Recreate firstPersonArm so swinging and swingTimer reset to their defaults
+        // (swinging=false, swingTimer=0). Without this, a mid-punch animation from the previous
+        // session leaks into the new game, showing the arm in a partially-extended position.
+        firstPersonArm = new FirstPersonArm();
 
         // Fix #307: Reset prevDamageFlashIntensity so the rising-edge detector fires correctly
         // on the first hit of a new session (prevents banner from being suppressed).


### PR DESCRIPTION
## Summary
Automated fix for issue #331.

## Changes
- Fix #331: Advance tooltipSystem while paused and reset firstPersonArm on restart

Closes #331