### PR TITLE
Fix #335: PAUSED state clears screen to hardcoded day-blue sky colour regardless of time of day

### DIFF
--- a/src/main/java/ragamuffin/core/RagamuffinGame.java
+++ b/src/main/java/ragamuffin/core/RagamuffinGame.java
@@ -665,7 +665,7 @@ public class RagamuffinGame extends ApplicationAdapter {
             }
         } else if (state == GameState.PAUSED) {
             // Paused - still render world but frozen
-            Gdx.gl.glClearColor(0.53f, 0.81f, 0.92f, 1f);
+            Gdx.gl.glClearColor(skyR, skyG, skyB, 1f);
             Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT | GL20.GL_DEPTH_BUFFER_BIT);
 
             // Fix #227: Render sun and clouds as part of the skybox — before 3D geometry


### PR DESCRIPTION
## Summary
Automated fix for issue #335.

## Changes
- Fix #335: Use skyR/skyG/skyB in PAUSED render path instead of hardcoded day-blue

Closes #335