### PR TITLE
Fix #339: firstPersonArm swing animation freezes mid-punch in PAUSED state

### DIFF
--- a/src/main/java/ragamuffin/core/RagamuffinGame.java
+++ b/src/main/java/ragamuffin/core/RagamuffinGame.java
@@ -702,6 +702,9 @@ public class RagamuffinGame extends ApplicationAdapter {
             // Fix #331: Advance tooltip countdown while paused so active tooltips
             // fade out and queued tooltips advance rather than freezing on-screen.
             tooltipSystem.update(delta);
+            // Fix #339: Advance arm swing animation while paused so a mid-punch
+            // swing completes rather than freezing in the extended position.
+            firstPersonArm.update(delta);
 
             // Render UI and pause menu
             renderUI();

--- a/src/test/java/ragamuffin/render/FirstPersonArmTest.java
+++ b/src/test/java/ragamuffin/render/FirstPersonArmTest.java
@@ -72,4 +72,23 @@ class FirstPersonArmTest {
         arm.update(0.24f);
         assertTrue(arm.isSwinging()); // Should still be swinging
     }
+
+    /**
+     * Fix #339: Arm swing animation must advance when update() is called regardless
+     * of game state. The PAUSED render path now calls firstPersonArm.update(delta)
+     * so a mid-punch swing completes rather than freezing in the extended position.
+     */
+    @Test
+    void swingAdvancesWhenUpdateCalledWhilePaused() {
+        arm.punch();
+        arm.update(0.05f); // Advance partway into the swing
+        float progressMidSwing = arm.getSwingProgress();
+        assertTrue(progressMidSwing > 0f, "Arm should be mid-swing after update");
+        assertTrue(arm.isSwinging(), "Arm should still be swinging");
+
+        // Simulate the PAUSED path calling update() — animation must continue to advance
+        arm.update(0.22f); // Advance past the remaining duration
+        assertFalse(arm.isSwinging(), "Arm should have completed swing after enough update time");
+        assertEquals(0f, arm.getSwingProgress(), 0.01f, "Arm should return to rest after swing completes");
+    }
 }


### PR DESCRIPTION
## Summary
Automated fix for issue #339.

## Changes
- Fix #339: Advance firstPersonArm swing animation while paused

Closes #339