### PR TITLE
Fix #345: restartGame() leaks SoundSystem footstep timer into new session

### DIFF
--- a/src/main/java/ragamuffin/audio/SoundSystem.java
+++ b/src/main/java/ragamuffin/audio/SoundSystem.java
@@ -106,6 +106,14 @@ public class SoundSystem {
     }
 
     /**
+     * Reset the footstep timer to zero. Call this when starting a new game session
+     * so the first footstep sound is not fired early due to a carried-over timer value.
+     */
+    public void resetFootstepTimer() {
+        footstepTimer = 0f;
+    }
+
+    /**
      * Update footstep timer and play footstep sounds when moving.
      * @param delta frame delta time in seconds
      * @param isMoving whether the player is currently moving

--- a/src/main/java/ragamuffin/core/RagamuffinGame.java
+++ b/src/main/java/ragamuffin/core/RagamuffinGame.java
@@ -1953,6 +1953,9 @@ public class RagamuffinGame extends ApplicationAdapter {
         }
         footstepDustTimer = 0f;
         rainTimer = 0f;
+        // Fix #345: Reset SoundSystem footstep timer so the first footstep of the new session
+        // is not fired early due to a mid-cycle timer value carried over from the previous session.
+        soundSystem.resetFootstepTimer();
 
         // Fix #299: Clear sticky punch state so auto-punch doesn't fire in the first frame
         // of the new game session (mirrors the same reset in transitionToPaused() and on death).


### PR DESCRIPTION
## Summary
Automated fix for issue #345.

## Changes
- Fix #345: Reset SoundSystem footstepTimer in restartGame()

Closes #345