### PR TITLE
Fix #363: restartGame() leaks inputHandler toggle-key state — UI overlays can open on frame 1 of new session

### DIFF
--- a/src/main/java/ragamuffin/core/RagamuffinGame.java
+++ b/src/main/java/ragamuffin/core/RagamuffinGame.java
@@ -2014,6 +2014,13 @@ public class RagamuffinGame extends ApplicationAdapter {
         punchHeldTimer = 0f;
         lastPunchTargetKey = null;
         inputHandler.resetPunchHeld();
+        // Fix #363: Clear stale toggle-key state so UI overlays (inventory, help, crafting)
+        // don't open on frame 1 of the new session if those keys were pressed on the same
+        // frame the Restart button was activated (mirrors the pattern used for resetPunchHeld).
+        inputHandler.resetInventory();
+        inputHandler.resetHelp();
+        inputHandler.resetCrafting();
+        inputHandler.resetInteract();
         // Fix #331: Recreate firstPersonArm so swinging and swingTimer reset to their defaults
         // (swinging=false, swingTimer=0). Without this, a mid-punch animation from the previous
         // session leaks into the new game, showing the arm in a partially-extended position.


### PR DESCRIPTION
## Summary
Automated fix for issue #363.

## Changes
- Fix #363: reset toggle-key state in restartGame() to prevent UI overlay leak

Closes #363