### PR TITLE
Fix #397: NPC speech timers freeze while paused — speech bubbles persist until resume then instantly expire

### DIFF
--- a/src/main/java/ragamuffin/ai/NPCManager.java
+++ b/src/main/java/ragamuffin/ai/NPCManager.java
@@ -1708,6 +1708,17 @@ public class NPCManager {
     }
 
     /**
+     * Tick speech timers for all NPCs by delta seconds.
+     * Called in the PAUSED branch so speech bubbles continue to count down while paused,
+     * preventing them from persisting through the pause then expiring instantly on resume (Fix #397).
+     */
+    public void tickSpeechTimers(float delta) {
+        for (NPC npc : npcs) {
+            npc.updateTimers(delta);
+        }
+    }
+
+    /**
      * Update police spawning — police patrol at night (seasonal: after sunset, before sunrise).
      * At dawn, all police are despawned. At night, officers are spawned up to the cap based on
      * player notoriety.

--- a/src/main/java/ragamuffin/core/RagamuffinGame.java
+++ b/src/main/java/ragamuffin/core/RagamuffinGame.java
@@ -826,6 +826,12 @@ public class RagamuffinGame extends ApplicationAdapter {
             // resume the cooldown expires almost immediately — flooding the player with police.
             npcManager.tickSpawnCooldown(delta);
 
+            // Fix #397: Tick NPC speech timers while paused so speech bubbles continue to count
+            // down. Without this, any active speech bubble freezes for the entire pause duration
+            // and then expires instantly on resume — the same pattern fixed for block decay (#391)
+            // and police spawn cooldown (#393).
+            npcManager.tickSpeechTimers(delta);
+
             // Fix #381: Advance healing resting timer while paused so the 5-second threshold
             // continues to accumulate and healing is not artificially delayed on resume.
             healingSystem.update(delta, player);


### PR DESCRIPTION
## Summary
Automated fix for issue #397.

## Changes
- Fix #397: tick NPC speech timers in PAUSED branch to prevent freeze/instant-expire

Closes #397