### PR TITLE
Fix #403: Fix: postArrestCooldown freezes while game is paused — player can exploit pause to extend re-arrest immunity

### DIFF
--- a/src/main/java/ragamuffin/ai/NPCManager.java
+++ b/src/main/java/ragamuffin/ai/NPCManager.java
@@ -1708,6 +1708,17 @@ public class NPCManager {
     }
 
     /**
+     * Tick the post-arrest cooldown by delta seconds.
+     * Called in the PAUSED branch so the cooldown continues to drain while the game is paused,
+     * preventing the player from exploiting pause to extend re-arrest immunity indefinitely (Fix #403).
+     */
+    public void tickPostArrestCooldown(float delta) {
+        if (postArrestCooldown > 0) {
+            postArrestCooldown = Math.max(0f, postArrestCooldown - delta);
+        }
+    }
+
+    /**
      * Tick speech timers for all NPCs by delta seconds.
      * Called in the PAUSED branch so speech bubbles continue to count down while paused,
      * preventing them from persisting through the pause then expiring instantly on resume (Fix #397).

--- a/src/main/java/ragamuffin/core/RagamuffinGame.java
+++ b/src/main/java/ragamuffin/core/RagamuffinGame.java
@@ -824,6 +824,9 @@ public class RagamuffinGame extends ApplicationAdapter {
             // Without this, policeSpawnCooldown freezes for the entire pause duration, and on
             // resume the cooldown expires almost immediately — flooding the player with police.
             npcManager.tickSpawnCooldown(delta);
+            // Fix #403: Tick post-arrest cooldown while paused so the player cannot exploit
+            // pause to extend re-arrest immunity indefinitely.
+            npcManager.tickPostArrestCooldown(delta);
 
             // Fix #397: Tick NPC speech timers while paused so speech bubbles continue to count
             // down. Without this, any active speech bubble freezes for the entire pause duration


### PR DESCRIPTION
## Summary
Automated fix for issue #403.

## Changes
- Fix #403: tick postArrestCooldown in PAUSED branch to close exploit

Closes #403