### PR TITLE
Fix #405: Fix: NPC knockback timer freezes while game is paused — player can exploit pause to keep NPCs permanently staggered

### DIFF
--- a/src/main/java/ragamuffin/ai/NPCManager.java
+++ b/src/main/java/ragamuffin/ai/NPCManager.java
@@ -1730,6 +1730,18 @@ public class NPCManager {
     }
 
     /**
+     * Tick knockback recovery timers for all NPCs by delta seconds.
+     * Called in the PAUSED branch so knockback velocity is cleared on schedule even while
+     * the game is paused, preventing the player from exploiting pause to extend NPC stagger
+     * indefinitely (Fix #405).
+     */
+    public void tickKnockbackTimers(float delta) {
+        for (NPC npc : npcs) {
+            npc.updateKnockback(delta);
+        }
+    }
+
+    /**
      * Update police spawning — police patrol at night (seasonal: after sunset, before sunrise).
      * At dawn, all police are despawned. At night, officers are spawned up to the cap based on
      * player notoriety.

--- a/src/main/java/ragamuffin/core/RagamuffinGame.java
+++ b/src/main/java/ragamuffin/core/RagamuffinGame.java
@@ -828,6 +828,11 @@ public class RagamuffinGame extends ApplicationAdapter {
             // pause to extend re-arrest immunity indefinitely.
             npcManager.tickPostArrestCooldown(delta);
 
+            // Fix #405: Tick NPC knockback recovery timers while paused so knockback velocity
+            // is cleared on schedule even when the game is paused. Without this, the player can
+            // exploit pause to keep NPCs permanently staggered by repeatedly pausing mid-knockback.
+            npcManager.tickKnockbackTimers(delta);
+
             // Fix #397: Tick NPC speech timers while paused so speech bubbles continue to count
             // down. Without this, any active speech bubble freezes for the entire pause duration
             // and then expires instantly on resume — the same pattern fixed for block decay (#391)


### PR DESCRIPTION
## Summary
Automated fix for issue #405.

## Changes
- Fix #405: tick NPC knockback timers in PAUSED branch to close stagger exploit

Closes #405