### PR TITLE
Fix #409: Fix #407: tickRecoveryTimers() defined but never called — KNOCKED_OUT recovery still freezes while paused

### DIFF
--- a/src/main/java/ragamuffin/core/RagamuffinGame.java
+++ b/src/main/java/ragamuffin/core/RagamuffinGame.java
@@ -833,6 +833,10 @@ public class RagamuffinGame extends ApplicationAdapter {
             // exploit pause to keep NPCs permanently staggered by repeatedly pausing mid-knockback.
             npcManager.tickKnockbackTimers(delta);
 
+            // Fix #407: Tick KNOCKED_OUT recovery timers while paused so NPCs cannot be kept
+            // permanently incapacitated by holding the pause menu open.
+            npcManager.tickRecoveryTimers(delta);
+
             // Fix #397: Tick NPC speech timers while paused so speech bubbles continue to count
             // down. Without this, any active speech bubble freezes for the entire pause duration
             // and then expires instantly on resume — the same pattern fixed for block decay (#391)

--- a/src/test/java/ragamuffin/entity/NPCTest.java
+++ b/src/test/java/ragamuffin/entity/NPCTest.java
@@ -217,11 +217,14 @@ class NPCTest {
         npc.setState(NPCState.KNOCKED_OUT);
         assertEquals(NPCState.KNOCKED_OUT, npc.getState());
 
-        // Timer accumulates while in KNOCKED_OUT state
+        // Timer accumulates while in KNOCKED_OUT state (updateTimers + tickKnockedOutTimer,
+        // mirroring what NPCManager.update() does for dead/knocked-out NPCs).
         npc.updateTimers(0.5f);
+        npc.tickKnockedOutTimer(0.5f);
         assertEquals(0.5f, npc.getKnockedOutTimer(), 0.001f);
 
         npc.updateTimers(0.5f);
+        npc.tickKnockedOutTimer(0.5f);
         assertEquals(1.0f, npc.getKnockedOutTimer(), 0.001f);
     }
 

--- a/src/test/java/ragamuffin/integration/Issue228NPCAnimationTest.java
+++ b/src/test/java/ragamuffin/integration/Issue228NPCAnimationTest.java
@@ -133,12 +133,14 @@ class Issue228NPCAnimationTest {
         npc.setVelocity(0f, 0f, 0f);
 
         npc.updateTimers(1.0f);
+        npc.tickKnockedOutTimer(1.0f);
 
         // animTime should NOT advance (no horizontal speed)
         assertEquals(animTimeBeforeKO, npc.getAnimTime(), 0.001f,
             "animTime must not advance while NPC is KNOCKED_OUT and stationary");
 
-        // knockedOutTimer should accumulate
+        // knockedOutTimer should accumulate (ticked via tickKnockedOutTimer,
+        // mirroring what NPCManager.update() does for knocked-out NPCs).
         assertEquals(1.0f, npc.getKnockedOutTimer(), 0.001f,
             "knockedOutTimer must accumulate while NPC is in KNOCKED_OUT state");
     }


### PR DESCRIPTION
## Summary
Automated fix for issue #409.

## Changes
- Fix #409: call tickRecoveryTimers(delta) in PAUSED branch to close KNOCKED_OUT exploit

Closes #409