### PR TITLE
Fix #423: Fix #419: tickSpeechTimers() advances attack cooldowns and animation state while paused

### DIFF
--- a/src/main/java/ragamuffin/ai/NPCManager.java
+++ b/src/main/java/ragamuffin/ai/NPCManager.java
@@ -1732,10 +1732,12 @@ public class NPCManager {
      * Tick speech timers for all NPCs by delta seconds.
      * Called in the PAUSED branch so speech bubbles continue to count down while paused,
      * preventing them from persisting through the pause then expiring instantly on resume (Fix #397).
+     * Only the speech timer is advanced — attack cooldowns, blink cycles, and animation
+     * timers remain frozen until the normal update() resumes in PLAYING state (Fix #423).
      */
     public void tickSpeechTimers(float delta) {
         for (NPC npc : npcs) {
-            npc.updateTimers(delta);
+            npc.tickSpeechOnly(delta);
         }
     }
 

--- a/src/main/java/ragamuffin/entity/NPC.java
+++ b/src/main/java/ragamuffin/entity/NPC.java
@@ -130,6 +130,20 @@ public class NPC {
     }
 
     /**
+     * Advance only the speech timer by delta seconds.
+     * Called in the PAUSED branch so speech bubbles count down while the game is paused
+     * without advancing attack cooldowns, blink cycles, or animation timers (Fix #423).
+     */
+    public void tickSpeechOnly(float delta) {
+        if (speechTimer > 0) {
+            speechTimer -= delta;
+            if (speechTimer <= 0) {
+                speechText = null;
+            }
+        }
+    }
+
+    /**
      * Update timers, facing angle, and animation — but NOT position.
      * Used by NPCManager which handles movement with world collision separately.
      */
@@ -413,6 +427,14 @@ public class NPC {
             default:
                 return FacialExpression.NEUTRAL;
         }
+    }
+
+    /**
+     * Returns the current value of the blink timer (counts up between blink cycles).
+     * Used in tests to verify the blink cycle does not advance while paused (Fix #423).
+     */
+    public float getBlinkTimer() {
+        return blinkTimer;
     }
 
     /**


### PR DESCRIPTION
## Summary
Automated fix for issue #423.

## Changes
- Fix #423: tickSpeechTimers() no longer drains attack cooldowns or advances animation state while paused

Closes #423