### PR TITLE
Fix #439: Fix: arrestPending flag never processed during CINEMATIC state — ghost arrest on first PLAYING frame

### DIFF
--- a/src/main/java/ragamuffin/core/RagamuffinGame.java
+++ b/src/main/java/ragamuffin/core/RagamuffinGame.java
@@ -563,6 +563,19 @@ public class RagamuffinGame extends ApplicationAdapter {
                 healingSystem.resetPosition(player.getPosition());
             }
 
+            // Fix #439: Process pending arrest during cinematic so the flag does not persist as a ghost.
+            // Mirrors Fix #367 (the PAUSED branch) — if police set arrestPending=true on the same frame
+            // the cinematic starts the flag must be evaluated here, not deferred to the first PLAYING frame.
+            if (npcManager.isArrestPending() && !player.isDead()) {
+                java.util.List<String> confiscated = arrestSystem.arrest(player, inventory);
+                String arrestMsg = ArrestSystem.buildArrestMessage(confiscated);
+                tooltipSystem.showMessage(arrestMsg, 4.0f);
+                npcManager.clearArrestPending();
+                greggsRaidSystem.reset();
+                player.getStreetReputation().removePoints(15);
+                healingSystem.resetPosition(player.getPosition());
+            }
+
             // Fix #437: Advance tooltip timers during the cinematic so queued tooltips
             // (e.g. FIRST_DEATH from respawnSystem, gang-territory warnings) count down
             // at the correct rate rather than freezing for the ~8-second fly-through.


### PR DESCRIPTION
## Summary
Automated fix for issue #439.

## Changes
- Fix #439: Process pending arrest during CINEMATIC state to prevent ghost arrest on first PLAYING frame

Closes #439