### PR TITLE
Fix #443: Fix: gameHUD.update() not called during CINEMATIC state — damage-reason banner timer freezes

### DIFF
--- a/src/main/java/ragamuffin/core/RagamuffinGame.java
+++ b/src/main/java/ragamuffin/core/RagamuffinGame.java
@@ -587,6 +587,9 @@ public class RagamuffinGame extends ApplicationAdapter {
             // cinematic so they expire at their intended rate rather than freezing for
             // the entire fly-through duration.
             player.updateFlash(delta);
+            // Fix #443: Advance HUD timers (damage-reason banner) during the cinematic
+            // so the banner counts down rather than freezing for the entire fly-through.
+            gameHUD.update(delta);
             player.updateDodge(delta);
             // Fix #437: Advance speech log entry timers during the cinematic so NPC
             // speech bubbles fade out rather than freezing on-screen.


### PR DESCRIPTION
## Summary
Automated fix for issue #443.

## Changes
- Fix #443: call gameHUD.update(delta) during CINEMATIC state

Closes #443