### PR TITLE
Fix #445: Fix: firstPersonArm.update() not called during CINEMATIC state — arm swing timer freezes

### DIFF
--- a/src/main/java/ragamuffin/core/RagamuffinGame.java
+++ b/src/main/java/ragamuffin/core/RagamuffinGame.java
@@ -591,6 +591,10 @@ public class RagamuffinGame extends ApplicationAdapter {
             // so the banner counts down rather than freezing for the entire fly-through.
             gameHUD.update(delta);
             player.updateDodge(delta);
+            // Fix #445: Advance arm swing/bob animation during cinematic so the
+            // idleTimer continues accumulating and the arm is in the correct phase
+            // when PLAYING starts.
+            firstPersonArm.update(delta);
             // Fix #437: Advance speech log entry timers during the cinematic so NPC
             // speech bubbles fade out rather than freezing on-screen.
             speechLogUI.update(npcManager.getNPCs(), delta);

--- a/src/main/java/ragamuffin/render/FirstPersonArm.java
+++ b/src/main/java/ragamuffin/render/FirstPersonArm.java
@@ -55,6 +55,15 @@ public class FirstPersonArm {
     }
 
     /**
+     * Returns the current idle bob timer value (seconds elapsed since construction
+     * or last reset). Used by tests to verify the timer advances during all game
+     * states (PLAYING, PAUSED, CINEMATIC).
+     */
+    public float getIdleTimer() {
+        return idleTimer;
+    }
+
+    /**
      * Get the current swing progress (0 = resting, 1 = fully extended).
      * Uses a smooth ease-in/ease-out curve for more natural motion.
      */


### PR DESCRIPTION
## Summary
Automated fix for issue #445.

## Changes
- Fix #445: call firstPersonArm.update(delta) during CINEMATIC state — arm swing timer freezes

Closes #445