### PR TITLE
Fix #469: Award achievement on first quest completion

### DIFF
--- a/src/main/java/ragamuffin/core/RagamuffinGame.java
+++ b/src/main/java/ragamuffin/core/RagamuffinGame.java
@@ -2054,6 +2054,8 @@ public class RagamuffinGame extends ApplicationAdapter {
             Quest completed = interactionSystem.pollLastQuestCompleted();
             if (completed != null) {
                 tooltipSystem.showMessage("Quest complete! " + completed.getGiver() + " is pleased.", 4.0f);
+                achievementSystem.unlock(AchievementType.FIRST_QUEST);
+                achievementSystem.increment(AchievementType.QUEST_MASTER);
             }
             // The dialogue is set on the NPC, which will be rendered as a speech bubble
             return;

--- a/src/main/java/ragamuffin/ui/AchievementType.java
+++ b/src/main/java/ragamuffin/ui/AchievementType.java
@@ -158,6 +158,18 @@ public enum AchievementType {
         "Haven't Got a Bus Pass",
         "Walked the equivalent of a marathon. The 68 wasn't running again.",
         1000
+    ),
+
+    // --- Quests ---
+    FIRST_QUEST(
+        "Community Spirit",
+        "Completed your first quest. Helping people? In this economy?",
+        1
+    ),
+    QUEST_MASTER(
+        "Odd Job Alan",
+        "Completed ten quests. Everyone on the estate knows you can get things done.",
+        10
     );
 
     private final String name;


### PR DESCRIPTION
## Summary
Automated fix for issue #469.

## Changes
- Fix #469: award achievements on quest completion

Closes #469