### PR TITLE
Fix #475: Fix SpriteBatch double-begin crash in QuestLogUI

### DIFF
--- a/src/main/java/ragamuffin/ui/QuestLogUI.java
+++ b/src/main/java/ragamuffin/ui/QuestLogUI.java
@@ -166,6 +166,7 @@ public class QuestLogUI {
 
             // Alternating row background
             if ((i % 2) == 0) {
+                spriteBatch.end();
                 com.badlogic.gdx.Gdx.gl.glEnable(GL20.GL_BLEND);
                 com.badlogic.gdx.Gdx.gl.glBlendFunc(GL20.GL_SRC_ALPHA, GL20.GL_ONE_MINUS_SRC_ALPHA);
                 shapeRenderer.begin(ShapeRenderer.ShapeType.Filled);


### PR DESCRIPTION
## Summary
Automated fix for issue #475.

## Changes
- Fix #475: add spriteBatch.end() before shapeRenderer in QuestLogUI even-row loop

Closes #475