### PR TITLE
Fix #477: Fix ESC key not closing quest log — triggers unintended state transition

### DIFF
--- a/src/main/java/ragamuffin/core/RagamuffinGame.java
+++ b/src/main/java/ragamuffin/core/RagamuffinGame.java
@@ -2448,6 +2448,9 @@ public class RagamuffinGame extends ApplicationAdapter {
         } else if (craftingUI.isVisible()) {
             craftingUI.hide();
             Gdx.input.setCursorCatched(true);
+        } else if (questLogUI.isVisible()) {
+            questLogUI.hide();
+            Gdx.input.setCursorCatched(true);
         } else if (state == GameState.PLAYING) {
             transitionToPaused();
         } else if (state == GameState.PAUSED) {


### PR DESCRIPTION
## Summary
Automated fix for issue #477.

## Changes
- Fix #477: add questLogUI.isVisible() branch in handleEscapePress()

Closes #477