### PR TITLE
Fix #483: Fix pause menu mouse click handler — wrong option indices

### DIFF
--- a/src/main/java/ragamuffin/core/RagamuffinGame.java
+++ b/src/main/java/ragamuffin/core/RagamuffinGame.java
@@ -1187,8 +1187,10 @@ public class RagamuffinGame extends ApplicationAdapter {
                 if (clicked == 0) {
                     transitionToPlaying();
                 } else if (clicked == 1) {
-                    restartGame();
+                    achievementsUI.toggle();
                 } else if (clicked == 2) {
+                    restartGame();
+                } else if (clicked == 3) {
                     Gdx.app.exit();
                 }
                 inputHandler.resetLeftClick();


### PR DESCRIPTION
## Summary
Automated fix for issue #483.

## Changes
- Fix #483: correct pause menu mouse click index-to-action mapping

Closes #483