### PR TITLE
Fix #485: Fix restartGame(): reset lastPlayerPosForDistance to new spawn position

### DIFF
--- a/src/main/java/ragamuffin/core/RagamuffinGame.java
+++ b/src/main/java/ragamuffin/core/RagamuffinGame.java
@@ -2573,6 +2573,12 @@ public class RagamuffinGame extends ApplicationAdapter {
         // Issue #166: Sync HealingSystem position after teleport so the next update()
         // does not compute a spurious speed from the restart spawn distance.
         healingSystem.resetPosition(player.getPosition());
+        // Fix #485: Reset distance-tracking vector to the new spawn position so the first
+        // updatePlayingSimulation() frame does not measure the full distance between the
+        // previous session's last position and the new spawn (mirrors the within-session
+        // respawn reset at lines 865-866).
+        distanceTravelledAchievement = 0f;
+        lastPlayerPosForDistance.set(player.getPosition());
         respawnSystem = new RespawnSystem();
         respawnSystem.setSpawnY(calculateSpawnHeight(world, 0, 0) + 1.0f);
         weatherSystem = new WeatherSystem();


### PR DESCRIPTION
## Summary
Automated fix for issue #485.

## Changes
- Fix #485: reset lastPlayerPosForDistance to new spawn position in restartGame()

Closes #485