### PR TITLE
Fix #489: Fix: achievementSystem not reset on restartGame()

### DIFF
--- a/src/main/java/ragamuffin/core/RagamuffinGame.java
+++ b/src/main/java/ragamuffin/core/RagamuffinGame.java
@@ -2620,6 +2620,9 @@ public class RagamuffinGame extends ApplicationAdapter {
         inputHandler.resetQuestLog(); // Fix #479: prevent stale Q-key from re-opening log on frame 1
         // Fix #461: Hide achievements overlay so it does not persist across game restarts.
         achievementsUI.hide();
+        // Fix #489: Reset achievement system so previous session's unlocks and progress
+        // do not carry over into the new game.
+        achievementSystem.reset();
         // Fix #365: Clear stale leftClickReleased flag so the inventory drag-and-drop
         // subsystem is not in an inconsistent state on frame 1 of the new session.
         // When the player mouse-clicks "Restart", touchUp() sets leftClickReleased=true

--- a/src/test/java/ragamuffin/ui/AchievementSystemTest.java
+++ b/src/test/java/ragamuffin/ui/AchievementSystemTest.java
@@ -203,6 +203,17 @@ class AchievementSystemTest {
     }
 
     @Test
+    void resetClearsUnlockedState() {
+        // Fix #489: after unlock + reset, the achievement must no longer be unlocked
+        system.unlock(AchievementType.FIRST_PUNCH);
+        assertTrue(system.isUnlocked(AchievementType.FIRST_PUNCH),
+                "Achievement must be unlocked before reset");
+        system.reset();
+        assertFalse(system.isUnlocked(AchievementType.FIRST_PUNCH),
+                "Achievement must not be unlocked after reset");
+    }
+
+    @Test
     void incrementToTargetUnlocksAndQueuesNotification() {
         AchievementType type = AchievementType.BRAWLER; // progressTarget > 1
         int target = type.getProgressTarget();


### PR DESCRIPTION
## Summary
Automated fix for issue #489.

## Changes
- Fix #489: reset achievementSystem on restartGame()

Closes #489