### PR TITLE
Fix #509: Fix spawnBuildingNPCs() using a throwaway BuildingQuestRegistry instead of the live interactionSystem registry

### DIFF
--- a/src/main/java/ragamuffin/core/RagamuffinGame.java
+++ b/src/main/java/ragamuffin/core/RagamuffinGame.java
@@ -277,6 +277,9 @@ public class RagamuffinGame extends ApplicationAdapter {
         npcManager = new NPCManager();
         npcManager.setBlockBreaker(blockBreaker);
         spawnInitialNPCs();
+        // Fix #509: Initialize interactionSystem before spawnBuildingNPCs() so the live
+        // quest registry is available when deciding which buildings get a quest-giver NPC.
+        interactionSystem = new InteractionSystem();
         spawnBuildingNPCs(); // Issue #462: spawn static quest-giver NPCs inside buildings
 
         // Phase 6: Initialize day/night cycle and lighting
@@ -299,8 +302,7 @@ public class RagamuffinGame extends ApplicationAdapter {
         // Issue #373: Initialize cinematic camera for city fly-through
         cinematicCamera = new ragamuffin.ui.CinematicCamera();
 
-        // Phase 11: Initialize CRITIC 1 systems
-        interactionSystem = new InteractionSystem();
+        // Phase 11: Initialize CRITIC 1 systems (interactionSystem already created above)
         healingSystem = new HealingSystem();
         respawnSystem = new RespawnSystem();
         respawnSystem.setSpawnY(calculateSpawnHeight(world, 0, 0) + 1.0f);
@@ -436,7 +438,7 @@ public class RagamuffinGame extends ApplicationAdapter {
      * Each NPC is stationed at the centre of its building's ground floor (Issue #462).
      */
     private void spawnBuildingNPCs() {
-        BuildingQuestRegistry registry = new BuildingQuestRegistry();
+        BuildingQuestRegistry registry = interactionSystem.getQuestRegistry();
         for (ragamuffin.world.Landmark landmark : world.getAllLandmarks()) {
             LandmarkType type = landmark.getType();
             if (registry.hasQuest(type)) {
@@ -2583,6 +2585,9 @@ public class RagamuffinGame extends ApplicationAdapter {
         npcManager = new NPCManager();
         npcManager.setBlockBreaker(blockBreaker);
         spawnInitialNPCs();
+        // Fix #509: Recreate interactionSystem before spawnBuildingNPCs() so the live
+        // quest registry is available when deciding which buildings get a quest-giver NPC.
+        interactionSystem = new InteractionSystem();
         spawnBuildingNPCs(); // Fix #479: spawn quest-giver NPCs inside buildings on restart
 
         // Reset time and lighting
@@ -2601,7 +2606,6 @@ public class RagamuffinGame extends ApplicationAdapter {
         // Reset game systems (blockBreaker already created above)
         tooltipSystem = new TooltipSystem();
         tooltipSystem.setOnTooltipShow(() -> soundSystem.play(ragamuffin.audio.SoundEffect.TOOLTIP));
-        interactionSystem = new InteractionSystem();
         // Fix #479: Recreate questLogUI bound to the fresh registry so old quests don't bleed in
         questLogUI = new ragamuffin.ui.QuestLogUI(interactionSystem.getQuestRegistry());
         // Issue #497: Recreate questTrackerUI bound to the fresh registry

--- a/src/test/java/ragamuffin/integration/Issue509BuildingNPCLiveRegistryTest.java
+++ b/src/test/java/ragamuffin/integration/Issue509BuildingNPCLiveRegistryTest.java
@@ -1,0 +1,143 @@
+package ragamuffin.integration;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import ragamuffin.ai.NPCManager;
+import ragamuffin.building.Inventory;
+import ragamuffin.core.BuildingQuestRegistry;
+import ragamuffin.core.InteractionSystem;
+import ragamuffin.entity.NPC;
+import ragamuffin.world.BlockType;
+import ragamuffin.world.Landmark;
+import ragamuffin.world.LandmarkType;
+import ragamuffin.world.World;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Tests for Issue #509: spawnBuildingNPCs() must use the live
+ * interactionSystem.getQuestRegistry() rather than a throwaway
+ * BuildingQuestRegistry instance.
+ */
+class Issue509BuildingNPCLiveRegistryTest {
+
+    private NPCManager npcManager;
+    private InteractionSystem interactionSystem;
+    private Inventory inventory;
+    private World world;
+
+    @BeforeEach
+    void setUp() {
+        npcManager = new NPCManager();
+        interactionSystem = new InteractionSystem();
+        inventory = new Inventory(36);
+
+        world = new World(42);
+        for (int x = -10; x < 120; x++) {
+            for (int z = -10; z < 120; z++) {
+                world.setBlock(x, 0, z, BlockType.GRASS);
+            }
+        }
+    }
+
+    /**
+     * Test 1: NPCs spawned via the live registry correspond exactly to the
+     * landmark types registered in interactionSystem.getQuestRegistry().
+     *
+     * Register several landmarks (some with quests, some without). Run the
+     * spawnBuildingNPCs() logic using the live registry. Verify the set of
+     * NPC buildingTypes matches exactly the set of landmark types that have
+     * a registered quest.
+     */
+    @Test
+    void test1_NPCBuildingTypesMatchLiveRegistry() {
+        BuildingQuestRegistry liveRegistry = interactionSystem.getQuestRegistry();
+
+        // Add landmarks — GREGGS and JEWELLER have quests; WAREHOUSE and PARK do not.
+        world.addLandmark(new Landmark(LandmarkType.GREGGS, 10, 0, 10, 8, 5, 8));
+        world.addLandmark(new Landmark(LandmarkType.JEWELLER, 30, 0, 30, 8, 5, 8));
+        world.addLandmark(new Landmark(LandmarkType.WAREHOUSE, 50, 0, 50, 20, 8, 15));
+        world.addLandmark(new Landmark(LandmarkType.PARK, 70, 0, 70, 30, 1, 30));
+
+        int before = npcManager.getNPCs().size();
+
+        // Simulate spawnBuildingNPCs() using the live registry (the fixed behaviour)
+        for (Landmark lm : world.getAllLandmarks()) {
+            LandmarkType type = lm.getType();
+            if (liveRegistry.hasQuest(type)) {
+                float x = lm.getPosition().x + lm.getWidth() / 2.0f;
+                float z = lm.getPosition().z + lm.getDepth() / 2.0f;
+                float y = lm.getPosition().y + 1.0f;
+                npcManager.spawnBuildingNPC(type, x, y, z);
+            }
+        }
+
+        List<NPC> allNPCs = npcManager.getNPCs();
+        // Collect building types of all newly spawned NPCs
+        Set<LandmarkType> spawnedTypes = new HashSet<>();
+        for (int i = before; i < allNPCs.size(); i++) {
+            LandmarkType bt = allNPCs.get(i).getBuildingType();
+            assertNotNull(bt, "Every building NPC spawned by the live registry should have a non-null buildingType");
+            spawnedTypes.add(bt);
+        }
+
+        // Exactly GREGGS and JEWELLER should have been spawned
+        assertTrue(spawnedTypes.contains(LandmarkType.GREGGS),
+                "GREGGS landmark should have produced a building NPC");
+        assertTrue(spawnedTypes.contains(LandmarkType.JEWELLER),
+                "JEWELLER landmark should have produced a building NPC");
+        assertFalse(spawnedTypes.contains(LandmarkType.WAREHOUSE),
+                "WAREHOUSE has no quest and should NOT produce a building NPC");
+        assertFalse(spawnedTypes.contains(LandmarkType.PARK),
+                "PARK has no quest and should NOT produce a building NPC");
+        assertEquals(2, spawnedTypes.size(),
+                "Exactly 2 building NPCs should be spawned (one per quest-registered landmark)");
+    }
+
+    /**
+     * Test 2: Interacting with a building NPC offers quest dialogue from the
+     * live registry, not from a fresh/reset copy.
+     *
+     * Spawn a JEWELLER NPC. Interact with it via the same InteractionSystem
+     * that owns the live registry. Verify the returned dialogue is the quest
+     * offer from the live registry (not blank, and mentions the jeweller quest).
+     */
+    @Test
+    void test2_InteractionUsesLiveRegistryDialogue() {
+        NPC npc = npcManager.spawnBuildingNPC(LandmarkType.JEWELLER, 50, 1, 50);
+        assertNotNull(npc, "Jeweller building NPC should be spawned");
+
+        String dialogue = interactionSystem.interactWithNPC(npc, inventory);
+
+        assertNotNull(dialogue, "Interaction with quest NPC should return dialogue");
+        assertFalse(dialogue.isBlank(), "Dialogue from live registry should not be blank");
+        // The jeweller quest in the live registry mentions "diamond" or "nicked"
+        assertTrue(dialogue.toLowerCase().contains("diamond")
+                        || dialogue.toLowerCase().contains("bring")
+                        || dialogue.toLowerCase().contains("nicked"),
+                "Dialogue should be from the live JEWELLER quest, got: " + dialogue);
+    }
+
+    /**
+     * Test 3: A throwaway BuildingQuestRegistry and the live registry both
+     * have the same quest registrations — confirming the fix preserves behaviour
+     * while eliminating the wasteful allocation.
+     *
+     * The live registry must return hasQuest()==true for every LandmarkType that
+     * a fresh BuildingQuestRegistry also returns hasQuest()==true for.
+     */
+    @Test
+    void test3_LiveRegistryHasSameQuestsAsThrowaway() {
+        BuildingQuestRegistry liveRegistry = interactionSystem.getQuestRegistry();
+        BuildingQuestRegistry throwaway = new BuildingQuestRegistry();
+
+        for (LandmarkType type : LandmarkType.values()) {
+            assertEquals(throwaway.hasQuest(type), liveRegistry.hasQuest(type),
+                    "Live registry and throwaway registry should agree on hasQuest() for " + type);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
Automated fix for issue #509.

## Changes
- Fix #509: Use live interactionSystem registry in spawnBuildingNPCs()

Closes #509