### PR TITLE
Fix #511: Quest tracker shows required items but not player's current count

### DIFF
--- a/src/main/java/ragamuffin/core/RagamuffinGame.java
+++ b/src/main/java/ragamuffin/core/RagamuffinGame.java
@@ -353,7 +353,8 @@ public class RagamuffinGame extends ApplicationAdapter {
         // Issue #464: Initialize quest log UI
         questLogUI = new ragamuffin.ui.QuestLogUI(interactionSystem.getQuestRegistry());
         // Issue #497: Initialize quest tracker UI (compact always-visible panel)
-        questTrackerUI = new ragamuffin.ui.QuestTrackerUI(interactionSystem.getQuestRegistry());
+        // Fix #511: Pass inventory so tracker can show current/required counts
+        questTrackerUI = new ragamuffin.ui.QuestTrackerUI(interactionSystem.getQuestRegistry(), inventory);
 
         loadingComplete = true;
         state = GameState.MENU;
@@ -2609,7 +2610,8 @@ public class RagamuffinGame extends ApplicationAdapter {
         // Fix #479: Recreate questLogUI bound to the fresh registry so old quests don't bleed in
         questLogUI = new ragamuffin.ui.QuestLogUI(interactionSystem.getQuestRegistry());
         // Issue #497: Recreate questTrackerUI bound to the fresh registry
-        questTrackerUI = new ragamuffin.ui.QuestTrackerUI(interactionSystem.getQuestRegistry());
+        // Fix #511: Pass inventory so tracker can show current/required counts
+        questTrackerUI = new ragamuffin.ui.QuestTrackerUI(interactionSystem.getQuestRegistry(), inventory);
         healingSystem = new HealingSystem();
         // Issue #166: Sync HealingSystem position after teleport so the next update()
         // does not compute a spurious speed from the restart spawn distance.

--- a/src/main/java/ragamuffin/ui/QuestTrackerUI.java
+++ b/src/main/java/ragamuffin/ui/QuestTrackerUI.java
@@ -6,6 +6,7 @@ import com.badlogic.gdx.graphics.g2d.BitmapFont;
 import com.badlogic.gdx.graphics.g2d.GlyphLayout;
 import com.badlogic.gdx.graphics.g2d.SpriteBatch;
 import com.badlogic.gdx.graphics.glutils.ShapeRenderer;
+import ragamuffin.building.Inventory;
 import ragamuffin.core.BuildingQuestRegistry;
 import ragamuffin.core.Quest;
 import ragamuffin.world.LandmarkType;
@@ -35,10 +36,12 @@ public class QuestTrackerUI {
     private static final float DESC_SCALE  = 0.75f;
 
     private final BuildingQuestRegistry questRegistry;
+    private final Inventory inventory;
     private boolean visible;
 
-    public QuestTrackerUI(BuildingQuestRegistry questRegistry) {
+    public QuestTrackerUI(BuildingQuestRegistry questRegistry, Inventory inventory) {
         this.questRegistry = questRegistry;
+        this.inventory = inventory;
         this.visible = true;
     }
 
@@ -131,8 +134,7 @@ public class QuestTrackerUI {
             if (quest.getRequiredMaterial() != null) {
                 font.getData().setScale(DESC_SCALE);
                 font.setColor(1f, 0.65f, 0.2f, 1f);
-                String mat = quest.getRequiredMaterial().name().toLowerCase().replace('_', ' ');
-                String progress = quest.getRequiredCount() + "x " + mat;
+                String progress = buildProgressString(quest);
                 GlyphLayout progLayout = new GlyphLayout(font, progress);
                 font.draw(spriteBatch, progress,
                         panelX + PANEL_WIDTH - PADDING - progLayout.width,
@@ -154,5 +156,19 @@ public class QuestTrackerUI {
         font.getData().setScale(1.2f); // restore default
         font.setColor(Color.WHITE);
         spriteBatch.end();
+    }
+
+    /**
+     * Builds the progress string for a COLLECT quest.
+     * Shows "current/requiredx material" when an inventory is available,
+     * or "requiredx material" otherwise.
+     */
+    String buildProgressString(Quest quest) {
+        String mat = quest.getRequiredMaterial().name().toLowerCase().replace('_', ' ');
+        if (inventory != null) {
+            int current = inventory.getItemCount(quest.getRequiredMaterial());
+            return current + "/" + quest.getRequiredCount() + "x " + mat;
+        }
+        return quest.getRequiredCount() + "x " + mat;
     }
 }


### PR DESCRIPTION
## Summary
Automated fix for issue #511.

## Changes
- Fix #511: Show current inventory count in quest tracker progress strings

Closes #511