### PR TITLE
Fix #519: QuestTrackerUI overlaps description and progress text at same Y position

### DIFF
--- a/src/main/java/ragamuffin/ui/QuestTrackerUI.java
+++ b/src/main/java/ragamuffin/ui/QuestTrackerUI.java
@@ -25,7 +25,7 @@ public class QuestTrackerUI {
     static final int MAX_VISIBLE = 3;
 
     private static final float PANEL_WIDTH   = 260f;
-    private static final float ROW_HEIGHT    = 44f;
+    private static final float ROW_HEIGHT    = 54f;
     private static final float HEADER_HEIGHT = 24f;
     private static final float PADDING       = 8f;
     private static final float MARGIN_RIGHT  = 14f;
@@ -124,13 +124,13 @@ public class QuestTrackerUI {
             String giverStr = "\u25CF " + quest.getGiver();
             font.draw(spriteBatch, giverStr, panelX + PADDING, rowY);
 
-            // Objective (truncated if needed)
+            // Objective (short summary, not the full NPC dialogue)
             font.getData().setScale(DESC_SCALE);
             font.setColor(0.78f, 0.78f, 0.78f, 1f);
-            String desc = quest.getDescription();
+            String desc = buildObjectiveString(quest);
             font.draw(spriteBatch, desc, panelX + PADDING + 6f, rowY - 18f);
 
-            // Progress hint for COLLECT quests
+            // Progress hint for COLLECT quests (rendered on its own line below the objective)
             if (quest.getRequiredMaterial() != null) {
                 font.getData().setScale(DESC_SCALE);
                 font.setColor(1f, 0.65f, 0.2f, 1f);
@@ -138,7 +138,7 @@ public class QuestTrackerUI {
                 GlyphLayout progLayout = new GlyphLayout(font, progress);
                 font.draw(spriteBatch, progress,
                         panelX + PANEL_WIDTH - PADDING - progLayout.width,
-                        rowY - 18f);
+                        rowY - 30f);
             }
         }
 
@@ -156,6 +156,23 @@ public class QuestTrackerUI {
         font.getData().setScale(1.2f); // restore default
         font.setColor(Color.WHITE);
         spriteBatch.end();
+    }
+
+    /**
+     * Builds a short at-a-glance objective string for the tracker panel.
+     * For COLLECT quests this is "Collect Nx material"; for other types the
+     * full description is truncated to 35 characters with an ellipsis.
+     */
+    String buildObjectiveString(Quest quest) {
+        if (quest.getType() == Quest.ObjectiveType.COLLECT && quest.getRequiredMaterial() != null) {
+            String mat = quest.getRequiredMaterial().name().toLowerCase().replace('_', ' ');
+            return "Collect " + quest.getRequiredCount() + "x " + mat;
+        }
+        String desc = quest.getDescription();
+        if (desc != null && desc.length() > 35) {
+            return desc.substring(0, 35) + "\u2026";
+        }
+        return desc != null ? desc : "";
     }
 
     /**

--- a/src/test/java/ragamuffin/ui/QuestTrackerUITest.java
+++ b/src/test/java/ragamuffin/ui/QuestTrackerUITest.java
@@ -107,6 +107,38 @@ class QuestTrackerUITest {
                 "MAX_VISIBLE must be at least 1 so at least one quest can be shown");
     }
 
+    // --- Objective string (Fix #519) ---
+
+    @Test
+    void objectiveStringForCollectQuestShowsCollectPrefix() {
+        Quest tesco = registry.getQuest(LandmarkType.TESCO_EXPRESS);
+        assertNotNull(tesco);
+        // Tesco quest: COLLECT 3x TIN_OF_BEANS
+        String obj = ui.buildObjectiveString(tesco);
+        assertEquals("Collect 3x tin of beans", obj,
+                "COLLECT quest objective must read 'Collect Nx material'");
+    }
+
+    @Test
+    void objectiveStringDoesNotExceed35Chars() {
+        // The Tesco description is much longer than 35 chars, but buildObjectiveString
+        // for COLLECT quests uses the auto-generated form which is always short.
+        Quest tesco = registry.getQuest(LandmarkType.TESCO_EXPRESS);
+        assertNotNull(tesco);
+        String obj = ui.buildObjectiveString(tesco);
+        assertTrue(obj.length() <= 35,
+                "Objective string must not exceed 35 characters to fit the tracker panel");
+    }
+
+    @Test
+    void objectiveStringNeverReturnsFullNPCDialogue() {
+        Quest tesco = registry.getQuest(LandmarkType.TESCO_EXPRESS);
+        assertNotNull(tesco);
+        String obj = ui.buildObjectiveString(tesco);
+        assertNotEquals(tesco.getDescription(), obj,
+                "Tracker must not show the full NPC dialogue as the objective");
+    }
+
     // --- Progress string (Fix #511) ---
 
     @Test


### PR DESCRIPTION
## Summary
Automated fix for issue #519.

## Changes
- Fix #519: Separate objective and progress lines in QuestTrackerUI, replace full NPC dialogue with short objective string

Closes #519