### PR TITLE
Fix #521: Fix quest reminder line: shows total required instead of remaining count

### DIFF
--- a/src/main/java/ragamuffin/core/BuildingQuestRegistry.java
+++ b/src/main/java/ragamuffin/core/BuildingQuestRegistry.java
@@ -216,8 +216,9 @@ public class BuildingQuestRegistry {
         if (quest.getType() == Quest.ObjectiveType.COLLECT && quest.getRequiredMaterial() != null) {
             if (inventory != null) {
                 int current = inventory.getItemCount(quest.getRequiredMaterial());
-                return "You've got " + current + " — still need " + quest.getRequiredCount() + " "
-                    + materialName(quest.getRequiredMaterial()) + " total. Don't let me down.";
+                int remaining = Math.max(0, quest.getRequiredCount() - current);
+                return "You've got " + current + " — need " + remaining + " more "
+                    + materialName(quest.getRequiredMaterial()) + ". Don't let me down.";
             }
             return "Still waiting on those " + quest.getRequiredCount() + " "
                 + materialName(quest.getRequiredMaterial()) + ". Don't let me down.";

--- a/src/test/java/ragamuffin/core/Issue517QuestReminderInventoryCountTest.java
+++ b/src/test/java/ragamuffin/core/Issue517QuestReminderInventoryCountTest.java
@@ -15,10 +15,10 @@ class Issue517QuestReminderInventoryCountTest {
 
     /**
      * When the player has partial items and an inventory is provided,
-     * the reminder line should contain both the current count and the required count.
+     * the reminder line should contain the current count and the remaining count (not total required).
      */
     @Test
-    void getQuestReminderLine_withInventory_includesCurrentAndRequiredCount() {
+    void getQuestReminderLine_withInventory_includesCurrentAndRemainingCount() {
         Quest quest = new Quest("test_quest", "Test NPC",
                 "Bring me 3 tins of beans.",
                 ObjectiveType.COLLECT, Material.TIN_OF_BEANS, 3,
@@ -33,8 +33,11 @@ class Issue517QuestReminderInventoryCountTest {
         assertNotNull(reminder);
         assertTrue(reminder.contains("1"),
                 "Reminder should contain the current count (1), got: " + reminder);
-        assertTrue(reminder.contains("3"),
-                "Reminder should contain the required count (3), got: " + reminder);
+        // remaining = 3 - 1 = 2; the message should say "need 2 more", not "still need 3 total"
+        assertTrue(reminder.contains("2"),
+                "Reminder should contain the remaining count (2), got: " + reminder);
+        assertFalse(reminder.contains("total"),
+                "Reminder should not say 'total' (misleading phrasing), got: " + reminder);
     }
 
     /**


### PR DESCRIPTION
## Summary
Automated fix for issue #521.

## Changes
- Fix #521: Compute remaining count in quest reminder instead of showing total required

Closes #521