### PR TITLE
Fix #525: ESC closes quest log while paused but wrongly re-catches cursor

### DIFF
--- a/src/main/java/ragamuffin/core/RagamuffinGame.java
+++ b/src/main/java/ragamuffin/core/RagamuffinGame.java
@@ -2501,19 +2501,19 @@ public class RagamuffinGame extends ApplicationAdapter {
         // Close any open UI first
         if (achievementsUI.isVisible()) {
             achievementsUI.hide();
-            Gdx.input.setCursorCatched(true);
+            Gdx.input.setCursorCatched(state == GameState.PLAYING);
         } else if (inventoryUI.isVisible()) {
             inventoryUI.hide();
-            Gdx.input.setCursorCatched(true);
+            Gdx.input.setCursorCatched(state == GameState.PLAYING);
         } else if (helpUI.isVisible()) {
             helpUI.hide();
-            Gdx.input.setCursorCatched(true);
+            Gdx.input.setCursorCatched(state == GameState.PLAYING);
         } else if (craftingUI.isVisible()) {
             craftingUI.hide();
-            Gdx.input.setCursorCatched(true);
+            Gdx.input.setCursorCatched(state == GameState.PLAYING);
         } else if (questLogUI.isVisible()) {
             questLogUI.hide();
-            Gdx.input.setCursorCatched(true);
+            Gdx.input.setCursorCatched(state == GameState.PLAYING);
         } else if (state == GameState.PLAYING) {
             transitionToPaused();
         } else if (state == GameState.PAUSED) {


### PR DESCRIPTION
## Summary
Automated fix for issue #525.

## Changes
- Fix #525: Restore correct cursor state when closing UI overlay while paused

Closes #525