### PR TITLE
Fix #533: Currency (shillings/pennies) are inert: no way to spend or trade them

### DIFF
--- a/src/main/java/ragamuffin/building/BlockDropTable.java
+++ b/src/main/java/ragamuffin/building/BlockDropTable.java
@@ -232,9 +232,12 @@ public class BlockDropTable {
                 return Material.BROKEN_PHONE;
             }
         } else if (landmark == LandmarkType.CASH_CONVERTER || landmark == LandmarkType.PAWN_SHOP) {
-            // Cash Converter/pawn shop drops dodgy DVDs and broken phones
+            // Cash Converter/pawn shop drops dodgy DVDs, broken phones, and loose change
             if (blockType == BlockType.BRICK || blockType == BlockType.GLASS) {
-                return Math.random() < 0.5 ? Material.DODGY_DVD : Material.BROKEN_PHONE;
+                double roll = Math.random();
+                if (roll < 0.33) return Material.DODGY_DVD;
+                else if (roll < 0.66) return Material.BROKEN_PHONE;
+                else return Math.random() < 0.5 ? Material.SHILLING : Material.PENNY;
             }
         } else if (landmark == LandmarkType.FIRE_STATION) {
             // Fire station drops fire extinguishers

--- a/src/main/java/ragamuffin/core/InteractionSystem.java
+++ b/src/main/java/ragamuffin/core/InteractionSystem.java
@@ -276,6 +276,7 @@ public class InteractionSystem {
     /**
      * Interact with an NPC (E key), with optional inventory for quest completion.
      * If the NPC is a building quest NPC, handles quest offer/progress/completion.
+     * If the NPC is a SHOPKEEPER and the player has shillings, offers to sell food.
      * @param npc The NPC to interact with
      * @param inventory Player inventory (may be null for non-quest interactions)
      * @return The dialogue text, or null if no interaction
@@ -314,7 +315,13 @@ public class InteractionSystem {
                 dialogue = "*bark*";
                 break;
             case SHOPKEEPER:
-                dialogue = SHOPKEEPER_DIALOGUE[RANDOM.nextInt(SHOPKEEPER_DIALOGUE.length)];
+                // If the player has currency, attempt a merchant purchase
+                if (inventory != null) {
+                    dialogue = handleShopkeeperPurchase(inventory);
+                }
+                if (dialogue == null) {
+                    dialogue = SHOPKEEPER_DIALOGUE[RANDOM.nextInt(SHOPKEEPER_DIALOGUE.length)];
+                }
                 break;
             case POSTMAN:
                 dialogue = POSTMAN_DIALOGUE[RANDOM.nextInt(POSTMAN_DIALOGUE.length)];
@@ -380,6 +387,44 @@ public class InteractionSystem {
 
         // Remind the player of the objective
         return BuildingQuestRegistry.getQuestReminderLine(quest, inventory);
+    }
+
+    /**
+     * Handle a shopkeeper merchant purchase using the player's currency.
+     * Tries to sell a sausage roll for 2 shillings, then an energy drink for 1 shilling,
+     * then crisps for 6 pennies.
+     * Returns the purchase dialogue if a transaction occurred (or was attempted),
+     * or null if the player has no currency at all.
+     */
+    private String handleShopkeeperPurchase(Inventory inventory) {
+        int shillings = inventory.getItemCount(Material.SHILLING);
+        int pennies = inventory.getItemCount(Material.PENNY);
+
+        if (shillings == 0 && pennies == 0) {
+            // No currency — fall through to generic shopkeeper dialogue
+            return null;
+        }
+
+        // Try best purchase first: sausage roll for 2 shillings
+        if (shillings >= SAUSAGE_ROLL_COST_SHILLINGS) {
+            PurchaseResult result = buySausageRoll(inventory);
+            return lastPurchaseMessage;
+        }
+
+        // Try energy drink for 1 shilling
+        if (shillings >= ENERGY_DRINK_COST_SHILLINGS) {
+            PurchaseResult result = buyEnergyDrink(inventory);
+            return lastPurchaseMessage;
+        }
+
+        // Try crisps for 6 pennies
+        if (pennies >= CRISPS_COST_PENNIES) {
+            PurchaseResult result = buyCrisps(inventory);
+            return lastPurchaseMessage;
+        }
+
+        // Player has some currency but not enough for anything
+        return "Got coins, have you? Sausage roll's 2 shillings, energy drink's 1 shilling, crisps are 6 pennies.";
     }
 
     /** The last quest that was completed (for UI feedback). */
@@ -471,6 +516,8 @@ public class InteractionSystem {
             case STAPLER:
             case PETROL_CAN:
             case DIAMOND:
+            case SHILLING:
+            case PENNY:
                 return true;
             default:
                 return false;
@@ -524,8 +571,99 @@ public class InteractionSystem {
                 return "On wheels, but not exactly portable. Leave it.";
             case STAPLER:
                 return "Satisfying click. Utterly useless out here.";
+            case SHILLING:
+                return "Shillings are currency — trade them with shopkeepers for food and goods.";
+            case PENNY:
+                return "A penny. Twelve pennies make a shilling. Trade them with shopkeepers.";
             default:
                 return null;
+        }
+    }
+
+    // --- Merchant purchase constants ---
+
+    /** Cost of a sausage roll from a shopkeeper (in shillings). */
+    public static final int SAUSAGE_ROLL_COST_SHILLINGS = 2;
+
+    /** Cost of an energy drink from a shopkeeper (in shillings). */
+    public static final int ENERGY_DRINK_COST_SHILLINGS = 1;
+
+    /** Cost of crisps from a shopkeeper (in pennies). */
+    public static final int CRISPS_COST_PENNIES = 6;
+
+    /**
+     * Result of a merchant purchase attempt.
+     */
+    public enum PurchaseResult {
+        /** Purchase succeeded — item added to inventory, currency deducted. */
+        SUCCESS,
+        /** Player has insufficient currency. */
+        INSUFFICIENT_FUNDS,
+        /** The NPC is not a shopkeeper or does not sell items. */
+        NOT_A_MERCHANT
+    }
+
+    /** The last purchase result message, set by attemptPurchase(). */
+    private String lastPurchaseMessage = null;
+
+    /** Get and clear the last purchase message. */
+    public String pollLastPurchaseMessage() {
+        String msg = lastPurchaseMessage;
+        lastPurchaseMessage = null;
+        return msg;
+    }
+
+    /**
+     * Attempt to buy a sausage roll from a SHOPKEEPER NPC for 2 shillings.
+     * On success deducts 2 shillings and adds 1 sausage roll to inventory.
+     *
+     * @return PurchaseResult indicating outcome
+     */
+    public PurchaseResult buySausageRoll(Inventory inventory) {
+        return purchaseItem(inventory, Material.SHILLING, SAUSAGE_ROLL_COST_SHILLINGS,
+            Material.SAUSAGE_ROLL, 1,
+            "You hand over 2 shillings. The shopkeeper passes you a sausage roll. Cheers.",
+            "You need 2 shillings for a sausage roll. Keep looking.");
+    }
+
+    /**
+     * Attempt to buy an energy drink from a SHOPKEEPER NPC for 1 shilling.
+     * On success deducts 1 shilling and adds 1 energy drink to inventory.
+     *
+     * @return PurchaseResult indicating outcome
+     */
+    public PurchaseResult buyEnergyDrink(Inventory inventory) {
+        return purchaseItem(inventory, Material.SHILLING, ENERGY_DRINK_COST_SHILLINGS,
+            Material.ENERGY_DRINK, 1,
+            "You hand over a shilling. The shopkeeper slides you an energy drink.",
+            "You need 1 shilling for an energy drink. Find some coins first.");
+    }
+
+    /**
+     * Attempt to buy crisps from a SHOPKEEPER NPC for 6 pennies.
+     * On success deducts 6 pennies and adds 1 crisps to inventory.
+     *
+     * @return PurchaseResult indicating outcome
+     */
+    public PurchaseResult buyCrisps(Inventory inventory) {
+        return purchaseItem(inventory, Material.PENNY, CRISPS_COST_PENNIES,
+            Material.CRISPS, 1,
+            "Six pennies for crisps. Not bad. Ready salted, obviously.",
+            "You need 6 pennies for a bag of crisps.");
+    }
+
+    private PurchaseResult purchaseItem(Inventory inventory,
+                                        Material currency, int currencyCost,
+                                        Material item, int itemCount,
+                                        String successMsg, String failMsg) {
+        if (inventory.getItemCount(currency) >= currencyCost) {
+            inventory.removeItem(currency, currencyCost);
+            inventory.addItem(item, itemCount);
+            lastPurchaseMessage = successMsg;
+            return PurchaseResult.SUCCESS;
+        } else {
+            lastPurchaseMessage = failMsg;
+            return PurchaseResult.INSUFFICIENT_FUNDS;
         }
     }
 }

--- a/src/test/java/ragamuffin/core/Issue533CurrencySpendingTest.java
+++ b/src/test/java/ragamuffin/core/Issue533CurrencySpendingTest.java
@@ -1,0 +1,292 @@
+package ragamuffin.core;
+
+import org.junit.jupiter.api.Test;
+import ragamuffin.ai.NPCManager;
+import ragamuffin.building.BlockDropTable;
+import ragamuffin.building.Inventory;
+import ragamuffin.building.Material;
+import ragamuffin.entity.NPC;
+import ragamuffin.entity.NPCType;
+import ragamuffin.world.BlockType;
+import ragamuffin.world.LandmarkType;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Tests for Issue #533 — currency (shillings/pennies) spending mechanic.
+ */
+class Issue533CurrencySpendingTest {
+
+    // --- canUseItem() ---
+
+    @Test
+    void shilling_canBeUsed() {
+        InteractionSystem system = new InteractionSystem();
+        assertTrue(system.canUseItem(Material.SHILLING),
+            "SHILLING should be usable (right-click)");
+    }
+
+    @Test
+    void penny_canBeUsed() {
+        InteractionSystem system = new InteractionSystem();
+        assertTrue(system.canUseItem(Material.PENNY),
+            "PENNY should be usable (right-click)");
+    }
+
+    // --- useItem() tooltip messages ---
+
+    @Test
+    void shilling_useItem_returnsTooltip() {
+        InteractionSystem system = new InteractionSystem();
+        String msg = system.useItem(Material.SHILLING, null, null);
+        assertNotNull(msg, "useItem(SHILLING) should return a tooltip message");
+        assertFalse(msg.isEmpty());
+    }
+
+    @Test
+    void penny_useItem_returnsTooltip() {
+        InteractionSystem system = new InteractionSystem();
+        String msg = system.useItem(Material.PENNY, null, null);
+        assertNotNull(msg, "useItem(PENNY) should return a tooltip message");
+        assertFalse(msg.isEmpty());
+    }
+
+    // --- Merchant purchase: buySausageRoll ---
+
+    @Test
+    void buySausageRoll_withEnoughShillings_succeeds() {
+        InteractionSystem system = new InteractionSystem();
+        Inventory inv = new Inventory(36);
+        inv.addItem(Material.SHILLING, 3);
+
+        InteractionSystem.PurchaseResult result = system.buySausageRoll(inv);
+
+        assertEquals(InteractionSystem.PurchaseResult.SUCCESS, result);
+        assertEquals(1, inv.getItemCount(Material.SAUSAGE_ROLL),
+            "Should have 1 sausage roll after purchase");
+        assertEquals(1, inv.getItemCount(Material.SHILLING),
+            "Should have 1 shilling remaining (3 - 2)");
+    }
+
+    @Test
+    void buySausageRoll_insufficientShillings_fails() {
+        InteractionSystem system = new InteractionSystem();
+        Inventory inv = new Inventory(36);
+        inv.addItem(Material.SHILLING, 1); // Only 1, need 2
+
+        InteractionSystem.PurchaseResult result = system.buySausageRoll(inv);
+
+        assertEquals(InteractionSystem.PurchaseResult.INSUFFICIENT_FUNDS, result);
+        assertEquals(0, inv.getItemCount(Material.SAUSAGE_ROLL),
+            "Should not receive sausage roll with insufficient shillings");
+        assertEquals(1, inv.getItemCount(Material.SHILLING),
+            "Shillings should be unchanged on failed purchase");
+    }
+
+    @Test
+    void buySausageRoll_noShillings_fails() {
+        InteractionSystem system = new InteractionSystem();
+        Inventory inv = new Inventory(36);
+
+        InteractionSystem.PurchaseResult result = system.buySausageRoll(inv);
+
+        assertEquals(InteractionSystem.PurchaseResult.INSUFFICIENT_FUNDS, result);
+    }
+
+    // --- Merchant purchase: buyEnergyDrink ---
+
+    @Test
+    void buyEnergyDrink_withEnoughShillings_succeeds() {
+        InteractionSystem system = new InteractionSystem();
+        Inventory inv = new Inventory(36);
+        inv.addItem(Material.SHILLING, 2);
+
+        InteractionSystem.PurchaseResult result = system.buyEnergyDrink(inv);
+
+        assertEquals(InteractionSystem.PurchaseResult.SUCCESS, result);
+        assertEquals(1, inv.getItemCount(Material.ENERGY_DRINK));
+        assertEquals(1, inv.getItemCount(Material.SHILLING), "Should have 1 shilling left");
+    }
+
+    @Test
+    void buyEnergyDrink_noShillings_fails() {
+        InteractionSystem system = new InteractionSystem();
+        Inventory inv = new Inventory(36);
+
+        InteractionSystem.PurchaseResult result = system.buyEnergyDrink(inv);
+
+        assertEquals(InteractionSystem.PurchaseResult.INSUFFICIENT_FUNDS, result);
+        assertEquals(0, inv.getItemCount(Material.ENERGY_DRINK));
+    }
+
+    // --- Merchant purchase: buyCrisps ---
+
+    @Test
+    void buyCrisps_withEnoughPennies_succeeds() {
+        InteractionSystem system = new InteractionSystem();
+        Inventory inv = new Inventory(36);
+        inv.addItem(Material.PENNY, 10);
+
+        InteractionSystem.PurchaseResult result = system.buyCrisps(inv);
+
+        assertEquals(InteractionSystem.PurchaseResult.SUCCESS, result);
+        assertEquals(1, inv.getItemCount(Material.CRISPS));
+        assertEquals(4, inv.getItemCount(Material.PENNY), "Should have 4 pennies left");
+    }
+
+    @Test
+    void buyCrisps_insufficientPennies_fails() {
+        InteractionSystem system = new InteractionSystem();
+        Inventory inv = new Inventory(36);
+        inv.addItem(Material.PENNY, 3); // Only 3, need 6
+
+        InteractionSystem.PurchaseResult result = system.buyCrisps(inv);
+
+        assertEquals(InteractionSystem.PurchaseResult.INSUFFICIENT_FUNDS, result);
+        assertEquals(0, inv.getItemCount(Material.CRISPS));
+        assertEquals(3, inv.getItemCount(Material.PENNY));
+    }
+
+    // --- Shopkeeper NPC interaction with currency ---
+
+    @Test
+    void shopkeeperInteraction_withShillings_triggersPurchase() {
+        InteractionSystem system = new InteractionSystem();
+        NPCManager npcManager = new NPCManager();
+        NPC shopkeeper = npcManager.spawnNPC(NPCType.SHOPKEEPER, 0, 0, -1f);
+
+        Inventory inv = new Inventory(36);
+        inv.addItem(Material.SHILLING, 5);
+
+        String dialogue = system.interactWithNPC(shopkeeper, inv);
+
+        assertNotNull(dialogue, "Shopkeeper should return dialogue when player has shillings");
+        // After interaction, player should have a food item (sausage roll costs 2 shillings)
+        int sausageRolls = inv.getItemCount(Material.SAUSAGE_ROLL);
+        int remainingShillings = inv.getItemCount(Material.SHILLING);
+        assertEquals(1, sausageRolls, "Player should receive a sausage roll");
+        assertEquals(3, remainingShillings, "Player should have 3 shillings remaining");
+    }
+
+    @Test
+    void shopkeeperInteraction_withPenniesOnly_buysCrisps() {
+        InteractionSystem system = new InteractionSystem();
+        NPCManager npcManager = new NPCManager();
+        NPC shopkeeper = npcManager.spawnNPC(NPCType.SHOPKEEPER, 0, 0, -1f);
+
+        Inventory inv = new Inventory(36);
+        inv.addItem(Material.PENNY, 8);
+
+        String dialogue = system.interactWithNPC(shopkeeper, inv);
+
+        assertNotNull(dialogue);
+        assertEquals(1, inv.getItemCount(Material.CRISPS),
+            "Player should receive crisps for pennies");
+        assertEquals(2, inv.getItemCount(Material.PENNY),
+            "Player should have 2 pennies remaining");
+    }
+
+    @Test
+    void shopkeeperInteraction_noCurrency_givesGenericDialogue() {
+        InteractionSystem system = new InteractionSystem();
+        NPCManager npcManager = new NPCManager();
+        NPC shopkeeper = npcManager.spawnNPC(NPCType.SHOPKEEPER, 0, 0, -1f);
+
+        Inventory inv = new Inventory(36);
+
+        String dialogue = system.interactWithNPC(shopkeeper, inv);
+
+        assertNotNull(dialogue, "Shopkeeper should still give dialogue with no currency");
+        // Should be generic shopkeeper dialogue — no purchase
+        assertEquals(0, inv.getItemCount(Material.SAUSAGE_ROLL));
+        assertEquals(0, inv.getItemCount(Material.ENERGY_DRINK));
+        assertEquals(0, inv.getItemCount(Material.CRISPS));
+    }
+
+    // --- BlockDropTable: currency drops ---
+
+    @Test
+    void cashConverter_brickBlock_canDropCurrency() {
+        BlockDropTable table = new BlockDropTable();
+        boolean foundShilling = false;
+        boolean foundPenny = false;
+        // Run enough iterations to see currency drop (33% chance per block break)
+        for (int i = 0; i < 500; i++) {
+            Material drop = table.getDrop(BlockType.BRICK, LandmarkType.CASH_CONVERTER);
+            if (drop == Material.SHILLING) foundShilling = true;
+            if (drop == Material.PENNY) foundPenny = true;
+        }
+        assertTrue(foundShilling || foundPenny,
+            "CASH_CONVERTER should drop SHILLING or PENNY from BRICK blocks");
+    }
+
+    @Test
+    void pawnShop_brickBlock_canDropCurrency() {
+        BlockDropTable table = new BlockDropTable();
+        boolean foundCurrency = false;
+        for (int i = 0; i < 500; i++) {
+            Material drop = table.getDrop(BlockType.BRICK, LandmarkType.PAWN_SHOP);
+            if (drop == Material.SHILLING || drop == Material.PENNY) {
+                foundCurrency = true;
+                break;
+            }
+        }
+        assertTrue(foundCurrency,
+            "PAWN_SHOP should sometimes drop SHILLING or PENNY from BRICK blocks");
+    }
+
+    @Test
+    void cashConverter_glassBlock_canDropCurrency() {
+        BlockDropTable table = new BlockDropTable();
+        boolean foundCurrency = false;
+        for (int i = 0; i < 500; i++) {
+            Material drop = table.getDrop(BlockType.GLASS, LandmarkType.CASH_CONVERTER);
+            if (drop == Material.SHILLING || drop == Material.PENNY) {
+                foundCurrency = true;
+                break;
+            }
+        }
+        assertTrue(foundCurrency,
+            "CASH_CONVERTER should sometimes drop currency from GLASS blocks");
+    }
+
+    // --- Purchase message polling ---
+
+    @Test
+    void purchaseMessage_isSetOnSuccess() {
+        InteractionSystem system = new InteractionSystem();
+        Inventory inv = new Inventory(36);
+        inv.addItem(Material.SHILLING, 2);
+
+        system.buySausageRoll(inv);
+        String msg = system.pollLastPurchaseMessage();
+
+        assertNotNull(msg, "A purchase message should be set after a successful buy");
+        assertFalse(msg.isEmpty());
+    }
+
+    @Test
+    void purchaseMessage_isSetOnFailure() {
+        InteractionSystem system = new InteractionSystem();
+        Inventory inv = new Inventory(36);
+
+        system.buySausageRoll(inv);
+        String msg = system.pollLastPurchaseMessage();
+
+        assertNotNull(msg, "A purchase message should be set even on failed buy");
+        assertFalse(msg.isEmpty());
+    }
+
+    @Test
+    void purchaseMessage_isNullAfterPoll() {
+        InteractionSystem system = new InteractionSystem();
+        Inventory inv = new Inventory(36);
+        inv.addItem(Material.SHILLING, 2);
+
+        system.buySausageRoll(inv);
+        system.pollLastPurchaseMessage(); // consume it
+        String msg = system.pollLastPurchaseMessage();
+
+        assertNull(msg, "pollLastPurchaseMessage() should return null after message consumed");
+    }
+}


### PR DESCRIPTION
## Summary
Automated fix for issue #533.

## Changes
- Fix #533: Implement currency spending mechanic for shillings and pennies

Closes #533