### PR TITLE
Fix #536: Add munching sound effect when player consumes crisps

### DIFF
--- a/src/main/java/ragamuffin/audio/SoundEffect.java
+++ b/src/main/java/ragamuffin/audio/SoundEffect.java
@@ -35,5 +35,6 @@ public enum SoundEffect {
 
     // Item use sounds
     ITEM_EAT,
-    ITEM_USE
+    ITEM_USE,
+    MUNCH      // Large munching sound for crisp consumption
 }

--- a/src/main/java/ragamuffin/audio/SoundSystem.java
+++ b/src/main/java/ragamuffin/audio/SoundSystem.java
@@ -23,6 +23,7 @@ public class SoundSystem {
     private static final float VOLUME_AMBIENT = 0.3f;
     private static final float VOLUME_EFFECTS = 0.7f;
     private static final float VOLUME_FOOTSTEPS = 0.2f;
+    private static final float VOLUME_MUNCH = 1.0f; // Large munching sound for crisps
 
     // Footstep timing
     private float footstepTimer;
@@ -183,6 +184,8 @@ public class SoundSystem {
             case FOOTSTEP_PAVEMENT:
             case FOOTSTEP_GRASS:
                 return VOLUME_FOOTSTEPS;
+            case MUNCH:
+                return VOLUME_MUNCH;
             default:
                 return VOLUME_EFFECTS;
         }

--- a/src/main/java/ragamuffin/core/RagamuffinGame.java
+++ b/src/main/java/ragamuffin/core/RagamuffinGame.java
@@ -2036,7 +2036,11 @@ public class RagamuffinGame extends ApplicationAdapter {
         if (interactionSystem.isFood(material)) {
             boolean consumed = interactionSystem.consumeFood(material, player, inventory);
             if (consumed) {
-                soundSystem.play(ragamuffin.audio.SoundEffect.ITEM_EAT);
+                if (material == ragamuffin.building.Material.CRISPS) {
+                    soundSystem.play(ragamuffin.audio.SoundEffect.MUNCH);
+                } else {
+                    soundSystem.play(ragamuffin.audio.SoundEffect.ITEM_EAT);
+                }
                 // Show any feedback message from the consumable
                 String consumeMsg = interactionSystem.getLastConsumeMessage();
                 if (consumeMsg != null) {

--- a/src/test/java/ragamuffin/audio/SoundSystemTest.java
+++ b/src/test/java/ragamuffin/audio/SoundSystemTest.java
@@ -163,6 +163,26 @@ public class SoundSystemTest {
     }
 
     @Test
+    public void testMunchSoundEffectExists() {
+        // MUNCH must be present in the enum for crisp consumption
+        boolean found = false;
+        for (SoundEffect effect : SoundEffect.values()) {
+            if (effect == SoundEffect.MUNCH) {
+                found = true;
+                break;
+            }
+        }
+        assertTrue(found, "MUNCH sound effect must exist in SoundEffect enum");
+    }
+
+    @Test
+    public void testPlayMunchSound() {
+        // Playing MUNCH should not throw even with no loaded sounds
+        assertDoesNotThrow(() -> soundSystem.play(SoundEffect.MUNCH),
+                "Playing MUNCH sound should not throw");
+    }
+
+    @Test
     public void testDispose() {
         // Should not throw even with no loaded sounds
         assertDoesNotThrow(() -> soundSystem.dispose());


### PR DESCRIPTION
## Summary
Automated fix for issue #536.

## Changes
- Fix #536: Add munching sound effect when player consumes crisps

Closes #536