### PR TITLE
Fix #543: Fix stale craftingSlotPressed after shop menu key intercept

### DIFF
--- a/src/main/java/ragamuffin/core/RagamuffinGame.java
+++ b/src/main/java/ragamuffin/core/RagamuffinGame.java
@@ -1436,6 +1436,7 @@ public class RagamuffinGame extends ApplicationAdapter {
             // and route them to item selection instead of changing the hotbar.
             if (activeShopkeeperNPC != null && activeShopkeeperNPC.isShopMenuOpen() && hotbarSlot <= 2) {
                 interactionSystem.selectShopItem(activeShopkeeperNPC, hotbarSlot + 1, inventory);
+                inputHandler.resetCraftingSlot(); // Issue #543: prevent stale craftingSlotPressed
             } else if (!craftingUI.isVisible()) {
                 hotbarUI.selectSlot(hotbarSlot);
             }


### PR DESCRIPTION
## Summary
Automated fix for issue #543.

## Changes
- Fix #543: Reset craftingSlotPressed when shop menu intercepts 1/2/3 key

Closes #543