### PR TITLE
Fix #545: Fix stale craftingSlotPressed auto-selecting recipe when crafting UI opens

### DIFF
--- a/src/main/java/ragamuffin/core/RagamuffinGame.java
+++ b/src/main/java/ragamuffin/core/RagamuffinGame.java
@@ -1439,6 +1439,7 @@ public class RagamuffinGame extends ApplicationAdapter {
                 inputHandler.resetCraftingSlot(); // Issue #543: prevent stale craftingSlotPressed
             } else if (!craftingUI.isVisible()) {
                 hotbarUI.selectSlot(hotbarSlot);
+                inputHandler.resetCraftingSlot(); // Issue #545: discard stale craftingSlotPressed when crafting UI is not open
             }
             inputHandler.resetHotbarSlot();
         }


### PR DESCRIPTION
## Summary
Automated fix for issue #545.

## Changes
- Fix #545: Reset craftingSlotPressed when crafting UI is not open

Closes #545