### PR TITLE
Fix #561: NPCs never drop currency, making shop system inaccessible

### DIFF
--- a/src/main/java/ragamuffin/ai/NPCManager.java
+++ b/src/main/java/ragamuffin/ai/NPCManager.java
@@ -1475,6 +1475,8 @@ public class NPCManager {
                 if (random.nextFloat() < 0.5f) {
                     inventory.addItem(Material.TIN_OF_BEANS, 1 + random.nextInt(2));
                 }
+                // Till float — always carries shillings
+                inventory.addItem(Material.SHILLING, 1 + random.nextInt(2));
                 break;
             case DELIVERY_DRIVER:
                 // Whatever's in the van
@@ -1495,6 +1497,10 @@ public class NPCManager {
                 if (random.nextFloat() < 0.3f) {
                     inventory.addItem(Material.SCRAP_METAL, 1);
                 }
+                // Small chance of loose change from their pocket
+                if (random.nextFloat() < 0.2f) {
+                    inventory.addItem(Material.PENNY, 1);
+                }
                 break;
             case DRUNK:
                 // Empties and kebab remnants
@@ -1502,11 +1508,17 @@ public class NPCManager {
                     inventory.addItem(Material.KEBAB, 1);
                 }
                 inventory.addItem(Material.GLASS, 1);
+                // Coin that fell out of their pocket
+                if (random.nextFloat() < 0.25f) {
+                    inventory.addItem(random.nextFloat() < 0.5f ? Material.PENNY : Material.SHILLING, 1);
+                }
                 break;
             case BUSKER:
-                // Guitar parts and loose change
+                // Guitar parts and busking money
                 inventory.addItem(Material.WOOD, 1 + random.nextInt(2));
                 inventory.addItem(Material.SCRAP_METAL, 1);
+                // Busking money — always has some pennies
+                inventory.addItem(Material.PENNY, 1 + random.nextInt(3));
                 break;
             case POLICE:
                 // Confiscated goods
@@ -1525,6 +1537,10 @@ public class NPCManager {
                 if (random.nextFloat() < 0.4f) {
                     inventory.addItem(Material.CRISPS, 1);
                 }
+                // Small chance of loose pennies from their purse
+                if (random.nextFloat() < 0.3f) {
+                    inventory.addItem(Material.PENNY, 1 + random.nextInt(2));
+                }
                 break;
             case SCHOOL_KID:
                 // Lunch money equivalent
@@ -1536,6 +1552,10 @@ public class NPCManager {
             case COUNCIL_MEMBER:
                 // Paperwork and office supplies
                 inventory.addItem(Material.CARDBOARD, 2 + random.nextInt(2));
+                // Small chance of a shilling — expenses money
+                if (random.nextFloat() < 0.3f) {
+                    inventory.addItem(Material.SHILLING, 1);
+                }
                 break;
             case COUNCIL_BUILDER:
                 // Building materials

--- a/src/main/java/ragamuffin/building/BlockDropTable.java
+++ b/src/main/java/ragamuffin/building/BlockDropTable.java
@@ -35,8 +35,16 @@ public class BlockDropTable {
             case DIRT:
                 return Material.DIRT;
             case PAVEMENT:
+                // 5% chance of a dropped coin found in the cracks
+                if (Math.random() < 0.05) {
+                    return Math.random() < 0.7 ? Material.PENNY : Material.SHILLING;
+                }
                 return Material.PAVEMENT_SLAB;
             case ROAD:
+                // 5% chance of a dropped coin on the road
+                if (Math.random() < 0.05) {
+                    return Math.random() < 0.7 ? Material.PENNY : Material.SHILLING;
+                }
                 return Material.ROAD_ASPHALT;
             case WOOD:
                 return Material.WOOD;

--- a/src/test/java/ragamuffin/building/BlockDropTableTest.java
+++ b/src/test/java/ragamuffin/building/BlockDropTableTest.java
@@ -53,15 +53,37 @@ class BlockDropTableTest {
     }
 
     @Test
-    void testPavementDropsPavementSlab() {
-        Material drop = dropTable.getDrop(BlockType.PAVEMENT, null);
-        assertEquals(Material.PAVEMENT_SLAB, drop);
+    void testPavementDropsPavementSlabOrCurrency() {
+        // PAVEMENT has a 5% chance to drop a coin (PENNY or SHILLING); otherwise PAVEMENT_SLAB.
+        // Run enough trials to confirm the result is always one of the three valid materials.
+        boolean sawSlab = false;
+        boolean sawCurrency = false;
+        for (int i = 0; i < 300; i++) {
+            Material drop = dropTable.getDrop(BlockType.PAVEMENT, null);
+            assertTrue(drop == Material.PAVEMENT_SLAB || drop == Material.PENNY || drop == Material.SHILLING,
+                    "PAVEMENT should drop PAVEMENT_SLAB, PENNY, or SHILLING, but got: " + drop);
+            if (drop == Material.PAVEMENT_SLAB) sawSlab = true;
+            if (drop == Material.PENNY || drop == Material.SHILLING) sawCurrency = true;
+        }
+        assertTrue(sawSlab, "PAVEMENT should usually drop PAVEMENT_SLAB");
+        assertTrue(sawCurrency, "PAVEMENT should occasionally drop a coin (PENNY or SHILLING)");
     }
 
     @Test
-    void testRoadDropsRoadAsphalt() {
-        Material drop = dropTable.getDrop(BlockType.ROAD, null);
-        assertEquals(Material.ROAD_ASPHALT, drop);
+    void testRoadDropsRoadAsphaltOrCurrency() {
+        // ROAD has a 5% chance to drop a coin (PENNY or SHILLING); otherwise ROAD_ASPHALT.
+        // Run enough trials to confirm the result is always one of the three valid materials.
+        boolean sawAsphalt = false;
+        boolean sawCurrency = false;
+        for (int i = 0; i < 300; i++) {
+            Material drop = dropTable.getDrop(BlockType.ROAD, null);
+            assertTrue(drop == Material.ROAD_ASPHALT || drop == Material.PENNY || drop == Material.SHILLING,
+                    "ROAD should drop ROAD_ASPHALT, PENNY, or SHILLING, but got: " + drop);
+            if (drop == Material.ROAD_ASPHALT) sawAsphalt = true;
+            if (drop == Material.PENNY || drop == Material.SHILLING) sawCurrency = true;
+        }
+        assertTrue(sawAsphalt, "ROAD should usually drop ROAD_ASPHALT");
+        assertTrue(sawCurrency, "ROAD should occasionally drop a coin (PENNY or SHILLING)");
     }
 
     @Test


### PR DESCRIPTION
## Summary
Automated fix for issue #561.

## Changes
- Fix #561: Add currency drops to NPC loot tables and block drops

Closes #561