### PR TITLE
Fix #565: questLogUI not hidden when resuming from PAUSED state

### DIFF
--- a/src/main/java/ragamuffin/core/RagamuffinGame.java
+++ b/src/main/java/ragamuffin/core/RagamuffinGame.java
@@ -2787,6 +2787,8 @@ public class RagamuffinGame extends ApplicationAdapter {
         pauseMenu.hide();
         // Fix #461: Hide achievements overlay on state transition so it doesn't persist
         achievementsUI.hide();
+        // Fix #565: Hide quest log overlay on state transition (mirrors achievementsUI fix)
+        questLogUI.hide();
         Gdx.input.setCursorCatched(true);
     }
 


### PR DESCRIPTION
## Summary
Automated fix for issue #565.

## Changes
- Fix #565: hide questLogUI in transitionToPlaying() to prevent soft-lock

Closes #565