### PR TITLE
Fix #585: restartGame() does not reset escapePressed, causing stale ESC to fire on first PLAYING frame after restart

### DIFF
--- a/src/main/java/ragamuffin/core/RagamuffinGame.java
+++ b/src/main/java/ragamuffin/core/RagamuffinGame.java
@@ -2769,6 +2769,9 @@ public class RagamuffinGame extends ApplicationAdapter {
         inputHandler.resetEnter();
         inputHandler.resetUp();
         inputHandler.resetDown();
+        // Fix #585: Clear stale ESC so frame 1 of the new session does not trigger
+        // transitionToPaused() (consistent with resetEscape() calls in sibling methods).
+        inputHandler.resetEscape();
         // Fix #331: Recreate firstPersonArm so swinging and swingTimer reset to their defaults
         // (swinging=false, swingTimer=0). Without this, a mid-punch animation from the previous
         // session leaks into the new game, showing the arm in a partially-extended position.


### PR DESCRIPTION
## Summary
Automated fix for issue #585.

## Changes
- Fix #585: reset escapePressed in restartGame()

Closes #585