### PR TITLE
Fix #591: transitionToPaused() does not reset escapePressed, causing immediate unintended unpause on first PAUSED frame

### DIFF
--- a/src/main/java/ragamuffin/core/RagamuffinGame.java
+++ b/src/main/java/ragamuffin/core/RagamuffinGame.java
@@ -2885,6 +2885,9 @@ public class RagamuffinGame extends ApplicationAdapter {
         // same frame as ESC does not activate a pause-menu option the player did not intend
         inputHandler.resetLeftClick();
         inputHandler.resetLeftClickReleased();
+        // Fix #591: Clear stale escapePressed so the first PAUSED frame does not immediately
+        // call handleEscapePress() again and bounce back to PLAYING
+        inputHandler.resetEscape();
     }
 
     public GameState getState() {


### PR DESCRIPTION
## Summary
Automated fix for issue #591.

## Changes
- Fix #591: reset escapePressed in transitionToPaused()

Closes #591