### PR TITLE
Fix #595: transitionToPlaying() does not reset escapePressed, causing immediate re-pause on resume

### DIFF
--- a/src/main/java/ragamuffin/core/RagamuffinGame.java
+++ b/src/main/java/ragamuffin/core/RagamuffinGame.java
@@ -2864,6 +2864,9 @@ public class RagamuffinGame extends ApplicationAdapter {
         // during the pause transition does not fire a spurious UI action on the first PLAYING frame
         inputHandler.resetLeftClick();
         inputHandler.resetLeftClickReleased();
+        // Fix #595: Clear stale escapePressed so ESC-to-resume does not immediately re-pause
+        // on the first PLAYING frame (mirrors the identical call in transitionToPaused() #591)
+        inputHandler.resetEscape();
         Gdx.input.setCursorCatched(true);
     }
 


### PR DESCRIPTION
## Summary
Automated fix for issue #595.

## Changes
- Fix #595: reset escapePressed in transitionToPlaying() to prevent immediate re-pause on resume

Closes #595