### PR TITLE
Fix #599: transitionToPlaying() does not reset enterPressed, causing stale Enter to fire crafting confirmation on first PLAYING frame after resume

### DIFF
--- a/src/main/java/ragamuffin/core/RagamuffinGame.java
+++ b/src/main/java/ragamuffin/core/RagamuffinGame.java
@@ -2872,6 +2872,9 @@ public class RagamuffinGame extends ApplicationAdapter {
         // Fix #595: Clear stale escapePressed so ESC-to-resume does not immediately re-pause
         // on the first PLAYING frame (mirrors the identical call in transitionToPaused() #591)
         inputHandler.resetEscape();
+        // Fix #599: Clear stale enterPressed so Enter-to-resume does not fire crafting confirmation
+        // on the first PLAYING frame (mirrors the identical call in transitionToPaused(), finishCinematic(), restartGame())
+        inputHandler.resetEnter();
         Gdx.input.setCursorCatched(true);
     }
 


### PR DESCRIPTION
## Summary
Automated fix for issue #599.

## Changes
- Fix #599: reset enterPressed in transitionToPlaying() to prevent phantom crafting on resume

Closes #599