### PR TITLE
Fix #611: finishCinematic() does not reset punchHeldTimer or lastPunchTargetKey, causing phantom hold-punch on first PLAYING frame after cinematic

### DIFF
--- a/src/main/java/ragamuffin/core/RagamuffinGame.java
+++ b/src/main/java/ragamuffin/core/RagamuffinGame.java
@@ -1353,6 +1353,11 @@ public class RagamuffinGame extends ApplicationAdapter {
         inputHandler.resetHotbarSlot();
         inputHandler.resetPunch();
         inputHandler.resetPunchHeld();
+        // Fix #611: Reset punchHeldTimer and lastPunchTargetKey alongside resetPunchHeld(),
+        // mirroring the identical pattern in transitionToPlaying(), transitionToPaused(), and
+        // the justDied block — prevents phantom hold-punch on first PLAYING frame after cinematic
+        punchHeldTimer = 0f;
+        lastPunchTargetKey = null;
         inputHandler.resetPlace();
         inputHandler.resetInventory();
         inputHandler.resetHelp();


### PR DESCRIPTION
## Summary
Automated fix for issue #611.

## Changes
- Fix #611: reset punchHeldTimer and lastPunchTargetKey in finishCinematic()

Closes #611