### PR TITLE
Fix #625: Respawn-completion blocks in PLAYING and PAUSED states do not clear activeShopkeeperNPC

### DIFF
--- a/src/main/java/ragamuffin/core/RagamuffinGame.java
+++ b/src/main/java/ragamuffin/core/RagamuffinGame.java
@@ -1002,6 +1002,12 @@ public class RagamuffinGame extends ApplicationAdapter {
                 helpUI.hide();
                 achievementsUI.hide();
                 questLogUI.hide();
+                // Fix #625: Close and clear any active shop menu so isUIBlocking() returns false
+                // after respawn — mirrors the CINEMATIC branch (Fix #623) and PAUSED branch (Fix #621).
+                if (activeShopkeeperNPC != null) {
+                    activeShopkeeperNPC.setShopMenuOpen(false);
+                    activeShopkeeperNPC = null;
+                }
             }
 
             // Phase 11: Trigger hunger warning tooltip
@@ -1219,6 +1225,12 @@ public class RagamuffinGame extends ApplicationAdapter {
                     helpUI.hide();
                     achievementsUI.hide();
                     questLogUI.hide();
+                    // Fix #625: Close and clear any active shop menu so isUIBlocking() returns false
+                    // after respawn — mirrors the CINEMATIC branch (Fix #623) and PLAYING branch (Fix #601).
+                    if (activeShopkeeperNPC != null) {
+                        activeShopkeeperNPC.setShopMenuOpen(false);
+                        activeShopkeeperNPC = null;
+                    }
                 }
                 if (respawnSystem.isRespawning()) {
                     renderDeathScreen();


### PR DESCRIPTION
## Summary
Automated fix for issue #625.

## Changes
- Fix #625: clear activeShopkeeperNPC in PLAYING and PAUSED respawn-completion blocks

Closes #625