### PR TITLE
Fix #637: touchUp sets leftClickReleased=true on every punch-end, causing phantom UI click-release when overlay opens mid-punch

### DIFF
--- a/src/main/java/ragamuffin/core/InputHandler.java
+++ b/src/main/java/ragamuffin/core/InputHandler.java
@@ -204,7 +204,9 @@ public class InputHandler implements InputProcessor {
         mouseY = screenY;
         if (button == Input.Buttons.LEFT) {
             punchHeld = false;
-            leftClickReleased = true;
+            if (!Gdx.input.isCursorCatched()) {
+                leftClickReleased = true;
+            }
         }
         return true;
     }
@@ -231,7 +233,9 @@ public class InputHandler implements InputProcessor {
     public boolean touchCancelled(int screenX, int screenY, int pointer, int button) {
         if (button == Input.Buttons.LEFT) {
             punchHeld = false;
-            leftClickReleased = true;
+            if (!Gdx.input.isCursorCatched()) {
+                leftClickReleased = true;
+            }
         }
         return false;
     }

--- a/src/test/java/ragamuffin/integration/Issue637TouchUpPhantomUIReleaseTest.java
+++ b/src/test/java/ragamuffin/integration/Issue637TouchUpPhantomUIReleaseTest.java
@@ -1,0 +1,195 @@
+package ragamuffin.integration;
+
+import com.badlogic.gdx.Input;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import ragamuffin.core.InputHandler;
+import ragamuffin.test.HeadlessTestHelper;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Integration tests for Issue #637:
+ * touchUp() sets leftClickReleased=true unconditionally on every punch-end,
+ * causing phantom UI click-release events when an overlay opens mid-punch.
+ *
+ * <p>Scenario: Player holds LMB to punch (cursor caught). Presses I to open
+ * inventory — this calls resetPunchHeld() and releases cursor. On the next
+ * frame, touchUp() fires and unconditionally sets leftClickReleased=true.
+ * handleUIInput() then sees leftClickReleased=true and misinterprets it as a
+ * drag-drop release, potentially moving/dropping items the player never
+ * intended to drag.
+ *
+ * <p>Fix: In touchUp() and touchCancelled(), only set leftClickReleased=true
+ * when the cursor is NOT caught (UI mode). When cursor is caught, the left
+ * button acts as punch and leftClickReleased must not be set. This mirrors
+ * the guard already applied in touchDown() for leftClickPressed.
+ *
+ * <p>Note: In tests the headless backend always reports isCursorCatched()==false,
+ * so the UI-mode path (leftClickReleased=true on touchUp) is the path exercised.
+ * The guard behaviour (leftClickReleased NOT set when cursor is caught) is
+ * verified by the structural parity with touchDown(), whose guard is the
+ * established pattern since Phase 1.
+ */
+class Issue637TouchUpPhantomUIReleaseTest {
+
+    private InputHandler inputHandler;
+
+    @BeforeAll
+    static void initGdx() {
+        HeadlessTestHelper.initHeadless();
+    }
+
+    @BeforeEach
+    void setUp() {
+        inputHandler = new InputHandler();
+    }
+
+    /**
+     * Test 1: touchUp() in UI mode (cursor not caught) sets leftClickReleased.
+     *
+     * Verifies the normal UI release path still works after the fix.
+     * In the test environment the headless backend always reports cursor as
+     * not caught, so this exercises the !isCursorCatched() branch.
+     */
+    @Test
+    void touchUp_inUIMode_setsLeftClickReleased() {
+        assertFalse(inputHandler.isLeftClickReleased(),
+                "Precondition: leftClickReleased must be false on fresh handler");
+
+        inputHandler.touchUp(0, 0, 0, Input.Buttons.LEFT);
+
+        assertTrue(inputHandler.isLeftClickReleased(),
+                "touchUp(LEFT) in UI mode (cursor not caught) must set leftClickReleased=true — " +
+                "normal drag-drop release must still be detected");
+    }
+
+    /**
+     * Test 2: touchUp() always clears punchHeld, regardless of cursor state.
+     *
+     * Releasing the left button must stop the punch animation whether the
+     * cursor is caught or not. The fix must not regress this behaviour.
+     */
+    @Test
+    void touchUp_alwaysClearsPunchHeld() {
+        // Set punchHeld via resetPunchHeld's inverse: force it true via direct field reset
+        // (we cannot call touchDown with cursor caught in tests, so we test clearing path)
+        assertFalse(inputHandler.isPunchHeld(),
+                "Precondition: punchHeld must be false on fresh handler");
+
+        inputHandler.touchUp(0, 0, 0, Input.Buttons.LEFT);
+
+        assertFalse(inputHandler.isPunchHeld(),
+                "touchUp(LEFT) must clear punchHeld regardless of cursor state");
+    }
+
+    /**
+     * Test 3: touchCancelled() in UI mode (cursor not caught) sets leftClickReleased.
+     *
+     * Mirrors the guard from touchUp() — touchCancelled() must also apply the
+     * same isCursorCatched() check for consistency.
+     */
+    @Test
+    void touchCancelled_inUIMode_setsLeftClickReleased() {
+        assertFalse(inputHandler.isLeftClickReleased(),
+                "Precondition: leftClickReleased must be false on fresh handler");
+
+        inputHandler.touchCancelled(0, 0, 0, Input.Buttons.LEFT);
+
+        assertTrue(inputHandler.isLeftClickReleased(),
+                "touchCancelled(LEFT) in UI mode (cursor not caught) must set leftClickReleased=true — " +
+                "the guard added to touchCancelled() must match touchUp()");
+    }
+
+    /**
+     * Test 4: touchCancelled() always clears punchHeld, regardless of cursor state.
+     *
+     * A touch cancel (window loses focus mid-punch) must stop the punch.
+     * The fix must not regress this behaviour from Issue #607.
+     */
+    @Test
+    void touchCancelled_alwaysClearsPunchHeld() {
+        assertFalse(inputHandler.isPunchHeld(),
+                "Precondition: punchHeld must be false on fresh handler");
+
+        inputHandler.touchCancelled(0, 0, 0, Input.Buttons.LEFT);
+
+        assertFalse(inputHandler.isPunchHeld(),
+                "touchCancelled(LEFT) must clear punchHeld regardless of cursor state");
+    }
+
+    /**
+     * Test 5: touchUp() and touchCancelled() produce identical observable state in UI mode.
+     *
+     * The fix must maintain parity between both methods: both must apply the
+     * isCursorCatched() guard identically. In the headless test context (cursor
+     * not caught) both paths must produce leftClickReleased=true and punchHeld=false.
+     */
+    @Test
+    void touchUpAndTouchCancelled_produceIdenticalStateInUIMode() {
+        InputHandler handlerA = new InputHandler();
+        InputHandler handlerB = new InputHandler();
+
+        handlerA.touchUp(0, 0, 0, Input.Buttons.LEFT);
+        handlerB.touchCancelled(0, 0, 0, Input.Buttons.LEFT);
+
+        assertEquals(handlerA.isPunchHeld(), handlerB.isPunchHeld(),
+                "punchHeld must be identical after touchUp vs touchCancelled (both false in UI mode)");
+        assertEquals(handlerA.isLeftClickReleased(), handlerB.isLeftClickReleased(),
+                "leftClickReleased must be identical after touchUp vs touchCancelled (both true in UI mode)");
+    }
+
+    /**
+     * Test 6: touchUp() with RIGHT button does not set leftClickReleased.
+     *
+     * Only LEFT button releases are relevant for leftClickReleased. Right button
+     * is the place-block action and must not pollute the UI release flag.
+     */
+    @Test
+    void touchUp_withRightButton_doesNotSetLeftClickReleased() {
+        inputHandler.touchUp(0, 0, 0, Input.Buttons.RIGHT);
+
+        assertFalse(inputHandler.isLeftClickReleased(),
+                "touchUp(RIGHT) must not set leftClickReleased — only LEFT button drives UI release");
+    }
+
+    /**
+     * Test 7: touchDown() guard is the mirror of the touchUp() fix.
+     *
+     * touchDown() with LEFT already guards leftClickPressed behind
+     * !isCursorCatched(). In the headless test context (cursor not caught),
+     * leftClickPressed must be set by touchDown(LEFT). This confirms the
+     * pre-existing guard pattern that the #637 fix mirrors for touchUp().
+     */
+    @Test
+    void touchDown_inUIMode_setsLeftClickPressed_confirmsMirrorPattern() {
+        assertFalse(inputHandler.isLeftClickPressed(),
+                "Precondition: leftClickPressed must be false on fresh handler");
+
+        inputHandler.touchDown(0, 0, 0, Input.Buttons.LEFT);
+
+        assertTrue(inputHandler.isLeftClickPressed(),
+                "touchDown(LEFT) in UI mode (cursor not caught) must set leftClickPressed=true — " +
+                "this confirms the guard pattern that #637 mirrors in touchUp()");
+    }
+
+    /**
+     * Test 8: resetLeftClickReleased() clears the flag set by touchUp() in UI mode.
+     *
+     * Verifies the reset method correctly clears leftClickReleased after a legitimate
+     * UI click-release, ensuring the fix does not break the normal UI event consumption
+     * cycle used by handleUIInput().
+     */
+    @Test
+    void resetLeftClickReleased_clearsFlag_afterUIModeTouchUp() {
+        inputHandler.touchUp(0, 0, 0, Input.Buttons.LEFT);
+        assertTrue(inputHandler.isLeftClickReleased(),
+                "Precondition: leftClickReleased must be true after touchUp in UI mode");
+
+        inputHandler.resetLeftClickReleased();
+
+        assertFalse(inputHandler.isLeftClickReleased(),
+                "resetLeftClickReleased() must clear leftClickReleased after a UI-mode touchUp");
+    }
+}


### PR DESCRIPTION
## Summary
Automated fix for issue #637.

## Changes
- Fix #637: only set leftClickReleased in touchUp/touchCancelled when cursor is not caught

Closes #637