### PR TITLE
Fix #643: Movement keys not cleared after arrest or respawn, causing immediate unwanted movement on first post-event frame

### DIFF
--- a/src/main/java/ragamuffin/core/InputHandler.java
+++ b/src/main/java/ragamuffin/core/InputHandler.java
@@ -110,6 +110,19 @@ public class InputHandler implements InputProcessor {
     public void resetHotbarSlot() { hotbarSlotPressed = -1; }
     public void resetCraftingSlot() { craftingSlotPressed = -1; }
 
+    /** Fix #643: Clear polled movement flags so a held WASD key does not cause
+     *  immediate unwanted movement on the first frame after arrest or respawn.
+     *  Must be called after {@link #update()} has already run for the current frame
+     *  so the cleared values are read by {@code updatePlayingInput()} before the
+     *  next frame's {@code update()} call overwrites them. */
+    public void resetMovement() {
+        forward = false;
+        backward = false;
+        left = false;
+        right = false;
+        sprintHeld = false;
+    }
+
     @Override
     public boolean keyDown(int keycode) {
         if (keycode == Input.Keys.ESCAPE) {

--- a/src/main/java/ragamuffin/core/RagamuffinGame.java
+++ b/src/main/java/ragamuffin/core/RagamuffinGame.java
@@ -661,6 +661,9 @@ public class RagamuffinGame extends ApplicationAdapter {
                 inputHandler.resetLeftClickReleased();
                 inputHandler.resetRightClick();
                 inputHandler.resetScroll();
+                // Fix #643: Clear polled movement flags so a held WASD/sprint key does not
+                // cause immediate unwanted movement on the first post-respawn PLAYING frame.
+                inputHandler.resetMovement();
                 // Fix #623: Close any UI overlays left open at the time of death so the player
                 // does not resume with inventory/crafting/help still showing (isUIBlocking() true).
                 // Mirrors the PLAYING (Fix #609) and PAUSED (Fix #617) branches.
@@ -718,6 +721,9 @@ public class RagamuffinGame extends ApplicationAdapter {
                 inputHandler.resetLeftClickReleased();
                 inputHandler.resetRightClick();
                 inputHandler.resetScroll();
+                // Fix #643: Clear polled movement flags so a held WASD/sprint key does not
+                // cause immediate unwanted movement on the first post-arrest PLAYING frame.
+                inputHandler.resetMovement();
                 // Fix #615: Close any UI overlays left open at the time of arrest so
                 // isUIBlocking() returns false on the first PLAYING frame post-arrest.
                 // Mirrors the identical hide() calls in the respawn-completion block.
@@ -1019,6 +1025,9 @@ public class RagamuffinGame extends ApplicationAdapter {
                 inputHandler.resetLeftClickReleased();
                 inputHandler.resetRightClick();
                 inputHandler.resetScroll();
+                // Fix #643: Clear polled movement flags so a held WASD/sprint key does not
+                // cause immediate unwanted movement on the first post-respawn PLAYING frame.
+                inputHandler.resetMovement();
                 // Fix #609: Close any UI overlays left open at the time of death so the player
                 // does not respawn with inventory/crafting/help still showing.
                 inventoryUI.hide();
@@ -1245,6 +1254,9 @@ public class RagamuffinGame extends ApplicationAdapter {
                     inputHandler.resetLeftClickReleased();
                     inputHandler.resetRightClick();
                     inputHandler.resetScroll();
+                    // Fix #643: Clear polled movement flags so a held WASD/sprint key does not
+                    // cause immediate unwanted movement on the first post-respawn PLAYING frame.
+                    inputHandler.resetMovement();
                     // Fix #617: Close any UI overlays left open at the time of death so the player
                     // does not resume with inventory/crafting/help still showing (isUIBlocking() true).
                     inventoryUI.hide();
@@ -1390,6 +1402,9 @@ public class RagamuffinGame extends ApplicationAdapter {
                 inputHandler.resetLeftClickReleased();
                 inputHandler.resetRightClick();
                 inputHandler.resetScroll();
+                // Fix #643: Clear polled movement flags so a held WASD/sprint key does not
+                // cause immediate unwanted movement on the first post-arrest PLAYING frame.
+                inputHandler.resetMovement();
                 // Fix #615: Close any UI overlays left open at the time of arrest so
                 // isUIBlocking() returns false on the first PLAYING frame post-arrest.
                 // Mirrors the identical hide() calls in the respawn-completion block.
@@ -1604,6 +1619,9 @@ public class RagamuffinGame extends ApplicationAdapter {
         inputHandler.resetRightClick();
         inputHandler.resetEscape();
         inputHandler.resetEnter();
+        // Fix #643: Clear polled movement flags so a held WASD/sprint key does not cause
+        // immediate unwanted movement on the first PLAYING frame after the cinematic ends.
+        inputHandler.resetMovement();
         Gdx.input.setCursorCatched(true);
     }
 
@@ -1964,6 +1982,9 @@ public class RagamuffinGame extends ApplicationAdapter {
             inputHandler.resetLeftClickReleased();
             inputHandler.resetRightClick();
             inputHandler.resetScroll();
+            // Fix #643: Clear polled movement flags so a held WASD/sprint key does not
+            // cause immediate unwanted movement on the first post-arrest PLAYING frame.
+            inputHandler.resetMovement();
             // Fix #615: Close any UI overlays left open at the time of arrest so
             // isUIBlocking() returns false on the first PLAYING frame post-arrest.
             // Mirrors the identical hide() calls in the respawn-completion block.
@@ -3123,6 +3144,9 @@ public class RagamuffinGame extends ApplicationAdapter {
         // Fix #585: Clear stale ESC so frame 1 of the new session does not trigger
         // transitionToPaused() (consistent with resetEscape() calls in sibling methods).
         inputHandler.resetEscape();
+        // Fix #643: Clear polled movement flags so a held WASD/sprint key does not cause
+        // immediate unwanted movement on frame 1 of the new session.
+        inputHandler.resetMovement();
         // Fix #331: Recreate firstPersonArm so swinging and swingTimer reset to their defaults
         // (swinging=false, swingTimer=0). Without this, a mid-punch animation from the previous
         // session leaks into the new game, showing the arm in a partially-extended position.
@@ -3205,6 +3229,9 @@ public class RagamuffinGame extends ApplicationAdapter {
         // Fix #599: Clear stale enterPressed so Enter-to-resume does not fire crafting confirmation
         // on the first PLAYING frame (mirrors the identical call in transitionToPaused(), finishCinematic(), restartGame())
         inputHandler.resetEnter();
+        // Fix #643: Clear polled movement flags so a held WASD/sprint key does not cause
+        // immediate unwanted movement on the first PLAYING frame after transitioning.
+        inputHandler.resetMovement();
         // Fix #633: Close and clear any active shop menu so isUIBlocking() returns false
         // after resume — mirrors the CINEMATIC branch (Fix #623) and the justDied paths (Fix #601/#621).
         if (activeShopkeeperNPC != null) {
@@ -3262,6 +3289,9 @@ public class RagamuffinGame extends ApplicationAdapter {
         // Fix #591: Clear stale escapePressed so the first PAUSED frame does not immediately
         // call handleEscapePress() again and bounce back to PLAYING
         inputHandler.resetEscape();
+        // Fix #643: Clear polled movement flags so a held WASD/sprint key does not cause
+        // immediate unwanted movement on the first PLAYING frame after resuming from pause.
+        inputHandler.resetMovement();
         // Fix #633: Close and clear any active shop menu so isUIBlocking() returns false
         // if the player resumes — mirrors the identical guard in transitionToPlaying() and
         // the CINEMATIC branch (Fix #623). Belt-and-suspenders: ESC normally closes the menu

--- a/src/test/java/ragamuffin/integration/Issue643MovementResetOnArrestAndRespawnTest.java
+++ b/src/test/java/ragamuffin/integration/Issue643MovementResetOnArrestAndRespawnTest.java
@@ -1,0 +1,331 @@
+package ragamuffin.integration;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import ragamuffin.core.InputHandler;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Integration tests for Issue #643 — movement keys not cleared after arrest or respawn,
+ * causing immediate unwanted movement on the first post-event frame.
+ *
+ * <p>Bug: {@link InputHandler#update()} polls live keyboard state and sets
+ * {@code forward}, {@code backward}, {@code left}, {@code right}, and {@code sprintHeld}
+ * via {@code Gdx.input.isKeyPressed()} every frame. After an arrest or respawn completion,
+ * all event-driven input flags were carefully reset, but the polled movement flags were
+ * never cleared — causing the player to immediately move in whichever direction was held
+ * at the moment of arrest or respawn.
+ *
+ * <p>Fix: Added {@link InputHandler#resetMovement()} which sets all five movement flags
+ * to {@code false}. This is called in every path that resets event-driven input flags:
+ * the PLAYING/PAUSED/CINEMATIC arrest blocks, PLAYING/PAUSED/CINEMATIC respawn-completion
+ * blocks, {@code transitionToPlaying()}, {@code transitionToPaused()},
+ * {@code finishCinematic()}, and {@code restartGame()}.
+ */
+class Issue643MovementResetOnArrestAndRespawnTest {
+
+    private InputHandler inputHandler;
+
+    @BeforeEach
+    void setUp() {
+        inputHandler = new InputHandler();
+    }
+
+    // -----------------------------------------------------------------------
+    // resetMovement() — basic contract
+    // -----------------------------------------------------------------------
+
+    @Test
+    void resetMovement_clearsForward() {
+        // Directly set the flag via the field-level setter pathway that the
+        // game's arrest/respawn logic would trigger.
+        // Note: forward/backward/left/right are set by update() polling Gdx.input,
+        // but resetMovement() sets them to false regardless.
+        // We verify the method exists and produces the correct post-state.
+        inputHandler.resetMovement();
+        assertFalse(inputHandler.isForward(),
+            "Fix #643: resetMovement() must set forward=false");
+    }
+
+    @Test
+    void resetMovement_clearsBackward() {
+        inputHandler.resetMovement();
+        assertFalse(inputHandler.isBackward(),
+            "Fix #643: resetMovement() must set backward=false");
+    }
+
+    @Test
+    void resetMovement_clearsLeft() {
+        inputHandler.resetMovement();
+        assertFalse(inputHandler.isLeft(),
+            "Fix #643: resetMovement() must set left=false");
+    }
+
+    @Test
+    void resetMovement_clearsRight() {
+        inputHandler.resetMovement();
+        assertFalse(inputHandler.isRight(),
+            "Fix #643: resetMovement() must set right=false");
+    }
+
+    @Test
+    void resetMovement_clearsSprintHeld() {
+        inputHandler.resetMovement();
+        assertFalse(inputHandler.isSprintHeld(),
+            "Fix #643: resetMovement() must set sprintHeld=false");
+    }
+
+    @Test
+    void resetMovement_clearsAllFiveFlags_whenAllWereTrue() {
+        // Simulate the scenario described in the bug: player was holding W + shift
+        // at the moment of arrest/respawn. After resetMovement(), all five flags
+        // must be false so updatePlayingInput() does not move the player on the next frame.
+        //
+        // We cannot call update() (which reads from Gdx.input) in a headless test, but we
+        // can verify that resetMovement() produces the correct post-state — this is the
+        // contract the game relies on.
+        inputHandler.resetMovement();
+
+        assertFalse(inputHandler.isForward(),   "Fix #643: forward must be false after resetMovement()");
+        assertFalse(inputHandler.isBackward(),  "Fix #643: backward must be false after resetMovement()");
+        assertFalse(inputHandler.isLeft(),      "Fix #643: left must be false after resetMovement()");
+        assertFalse(inputHandler.isRight(),     "Fix #643: right must be false after resetMovement()");
+        assertFalse(inputHandler.isSprintHeld(),"Fix #643: sprintHeld must be false after resetMovement()");
+    }
+
+    @Test
+    void resetMovement_isIdempotent_whenAlreadyFalse() {
+        // All flags default to false; calling resetMovement() on a fresh handler must not throw
+        // and must leave all flags false.
+        assertDoesNotThrow(() -> inputHandler.resetMovement(),
+            "Fix #643: resetMovement() must not throw when movement flags are already false");
+
+        assertFalse(inputHandler.isForward());
+        assertFalse(inputHandler.isBackward());
+        assertFalse(inputHandler.isLeft());
+        assertFalse(inputHandler.isRight());
+        assertFalse(inputHandler.isSprintHeld());
+    }
+
+    @Test
+    void resetMovement_doesNotAffectOtherInputFlags() {
+        // resetMovement() must only touch the five movement-related flags; all event-driven
+        // flags must remain unaffected (either their existing value or unchanged).
+        inputHandler.keyDown(com.badlogic.gdx.Input.Keys.ESCAPE);
+        inputHandler.keyDown(com.badlogic.gdx.Input.Keys.I);
+        inputHandler.keyDown(com.badlogic.gdx.Input.Keys.SPACE);
+
+        inputHandler.resetMovement();
+
+        // Event-driven flags set by keyDown() should still be set
+        assertTrue(inputHandler.isEscapePressed(),
+            "Fix #643: resetMovement() must not clear escapePressed");
+        assertTrue(inputHandler.isInventoryPressed(),
+            "Fix #643: resetMovement() must not clear inventoryPressed");
+        assertTrue(inputHandler.isJumpPressed(),
+            "Fix #643: resetMovement() must not clear jumpPressed");
+    }
+
+    // -----------------------------------------------------------------------
+    // Simulate arrest/respawn reset sequences — verify movement flags included
+    // -----------------------------------------------------------------------
+
+    /**
+     * Applies the full input-flag reset that the arrest/respawn blocks perform,
+     * now including resetMovement() (Fix #643).
+     */
+    private static void simulateArrestOrRespawnReset(InputHandler ih) {
+        ih.resetEscape();
+        ih.resetPunch();
+        ih.resetPunchHeld();
+        ih.resetPlace();
+        ih.resetInventory();
+        ih.resetHelp();
+        ih.resetCrafting();
+        ih.resetAchievements();
+        ih.resetQuestLog();
+        ih.resetInteract();
+        ih.resetJump();
+        ih.resetDodge();
+        ih.resetEnter();
+        ih.resetUp();
+        ih.resetDown();
+        ih.resetHotbarSlot();
+        ih.resetCraftingSlot();
+        ih.resetLeftClick();
+        ih.resetLeftClickReleased();
+        ih.resetRightClick();
+        ih.resetScroll();
+        // Fix #643: The missing piece — clear polled movement flags
+        ih.resetMovement();
+    }
+
+    @Test
+    void arrestReset_clearsMovementFlags() {
+        // Simulate: player was holding WASD+sprint at moment of arrest.
+        // After the arrest reset sequence, movement flags must be false.
+        simulateArrestOrRespawnReset(inputHandler);
+
+        assertFalse(inputHandler.isForward(),    "Fix #643: forward must be cleared on arrest reset");
+        assertFalse(inputHandler.isBackward(),   "Fix #643: backward must be cleared on arrest reset");
+        assertFalse(inputHandler.isLeft(),       "Fix #643: left must be cleared on arrest reset");
+        assertFalse(inputHandler.isRight(),      "Fix #643: right must be cleared on arrest reset");
+        assertFalse(inputHandler.isSprintHeld(), "Fix #643: sprintHeld must be cleared on arrest reset");
+    }
+
+    @Test
+    void arrestReset_alsoClearsAllEventDrivenFlags() {
+        // Verify the complete reset sequence (event-driven + movement) clears everything
+        inputHandler.keyDown(com.badlogic.gdx.Input.Keys.ESCAPE);
+        inputHandler.keyDown(com.badlogic.gdx.Input.Keys.I);
+        inputHandler.keyDown(com.badlogic.gdx.Input.Keys.E);
+        inputHandler.keyDown(com.badlogic.gdx.Input.Keys.SPACE);
+        inputHandler.scrolled(0, 3f);
+
+        simulateArrestOrRespawnReset(inputHandler);
+
+        assertFalse(inputHandler.isEscapePressed(),    "Fix #643: escapePressed must be cleared");
+        assertFalse(inputHandler.isInventoryPressed(), "Fix #643: inventoryPressed must be cleared");
+        assertFalse(inputHandler.isInteractPressed(),  "Fix #643: interactPressed must be cleared");
+        assertFalse(inputHandler.isJumpPressed(),      "Fix #643: jumpPressed must be cleared");
+        assertEquals(0f, inputHandler.getScrollAmountY(), 0f, "Fix #643: scroll must be cleared");
+        // And movement
+        assertFalse(inputHandler.isForward(),    "Fix #643: forward must be cleared");
+        assertFalse(inputHandler.isBackward(),   "Fix #643: backward must be cleared");
+        assertFalse(inputHandler.isLeft(),       "Fix #643: left must be cleared");
+        assertFalse(inputHandler.isRight(),      "Fix #643: right must be cleared");
+        assertFalse(inputHandler.isSprintHeld(), "Fix #643: sprintHeld must be cleared");
+    }
+
+    @Test
+    void respawnReset_clearsMovementFlags() {
+        // Simulate: player was holding WASD during the death-screen countdown.
+        // After respawn completion reset, movement flags must be false.
+        simulateArrestOrRespawnReset(inputHandler);
+
+        assertFalse(inputHandler.isForward(),    "Fix #643: forward must be cleared on respawn");
+        assertFalse(inputHandler.isBackward(),   "Fix #643: backward must be cleared on respawn");
+        assertFalse(inputHandler.isLeft(),       "Fix #643: left must be cleared on respawn");
+        assertFalse(inputHandler.isRight(),      "Fix #643: right must be cleared on respawn");
+        assertFalse(inputHandler.isSprintHeld(), "Fix #643: sprintHeld must be cleared on respawn");
+    }
+
+    // -----------------------------------------------------------------------
+    // Transition methods — verify movement flags included in their resets
+    // -----------------------------------------------------------------------
+
+    /** Simulates the transitionToPlaying() input-reset sequence including Fix #643. */
+    private static void simulateTransitionToPlayingReset(InputHandler ih) {
+        ih.resetCraftingSlot();
+        ih.resetHotbarSlot();
+        ih.resetPunch();
+        ih.resetPunchHeld();
+        ih.resetPlace();
+        ih.resetInventory();
+        ih.resetHelp();
+        ih.resetCrafting();
+        ih.resetAchievements();
+        ih.resetQuestLog();
+        ih.resetScroll();
+        ih.resetInteract();
+        ih.resetJump();
+        ih.resetDodge();
+        ih.resetUp();
+        ih.resetDown();
+        ih.resetLeftClick();
+        ih.resetLeftClickReleased();
+        ih.resetRightClick();
+        ih.resetEscape();
+        ih.resetEnter();
+        // Fix #643
+        ih.resetMovement();
+    }
+
+    @Test
+    void transitionToPlaying_clearsMovementFlags() {
+        simulateTransitionToPlayingReset(inputHandler);
+
+        assertFalse(inputHandler.isForward(),    "Fix #643: forward must be cleared in transitionToPlaying()");
+        assertFalse(inputHandler.isBackward(),   "Fix #643: backward must be cleared in transitionToPlaying()");
+        assertFalse(inputHandler.isLeft(),       "Fix #643: left must be cleared in transitionToPlaying()");
+        assertFalse(inputHandler.isRight(),      "Fix #643: right must be cleared in transitionToPlaying()");
+        assertFalse(inputHandler.isSprintHeld(), "Fix #643: sprintHeld must be cleared in transitionToPlaying()");
+    }
+
+    /** Simulates the finishCinematic() input-reset sequence including Fix #643. */
+    private static void simulateFinishCinematicReset(InputHandler ih) {
+        ih.resetCraftingSlot();
+        ih.resetHotbarSlot();
+        ih.resetPunch();
+        ih.resetPunchHeld();
+        ih.resetPlace();
+        ih.resetInventory();
+        ih.resetHelp();
+        ih.resetCrafting();
+        ih.resetAchievements();
+        ih.resetQuestLog();
+        ih.resetScroll();
+        ih.resetInteract();
+        ih.resetJump();
+        ih.resetDodge();
+        ih.resetUp();
+        ih.resetDown();
+        ih.resetLeftClick();
+        ih.resetLeftClickReleased();
+        ih.resetRightClick();
+        ih.resetEscape();
+        ih.resetEnter();
+        // Fix #643
+        ih.resetMovement();
+    }
+
+    @Test
+    void finishCinematic_clearsMovementFlags() {
+        simulateFinishCinematicReset(inputHandler);
+
+        assertFalse(inputHandler.isForward(),    "Fix #643: forward must be cleared in finishCinematic()");
+        assertFalse(inputHandler.isBackward(),   "Fix #643: backward must be cleared in finishCinematic()");
+        assertFalse(inputHandler.isLeft(),       "Fix #643: left must be cleared in finishCinematic()");
+        assertFalse(inputHandler.isRight(),      "Fix #643: right must be cleared in finishCinematic()");
+        assertFalse(inputHandler.isSprintHeld(), "Fix #643: sprintHeld must be cleared in finishCinematic()");
+    }
+
+    /** Simulates the restartGame() input-reset sequence including Fix #643. */
+    private static void simulateRestartGameReset(InputHandler ih) {
+        ih.resetPunchHeld();
+        ih.resetInventory();
+        ih.resetHelp();
+        ih.resetCrafting();
+        ih.resetAchievements();
+        ih.resetInteract();
+        ih.resetQuestLog();
+        ih.resetLeftClick();
+        ih.resetLeftClickReleased();
+        ih.resetRightClick();
+        ih.resetScroll();
+        ih.resetPunch();
+        ih.resetPlace();
+        ih.resetJump();
+        ih.resetDodge();
+        ih.resetHotbarSlot();
+        ih.resetCraftingSlot();
+        ih.resetEnter();
+        ih.resetUp();
+        ih.resetDown();
+        ih.resetEscape();
+        // Fix #643
+        ih.resetMovement();
+    }
+
+    @Test
+    void restartGame_clearsMovementFlags() {
+        simulateRestartGameReset(inputHandler);
+
+        assertFalse(inputHandler.isForward(),    "Fix #643: forward must be cleared in restartGame()");
+        assertFalse(inputHandler.isBackward(),   "Fix #643: backward must be cleared in restartGame()");
+        assertFalse(inputHandler.isLeft(),       "Fix #643: left must be cleared in restartGame()");
+        assertFalse(inputHandler.isRight(),      "Fix #643: right must be cleared in restartGame()");
+        assertFalse(inputHandler.isSprintHeld(), "Fix #643: sprintHeld must be cleared in restartGame()");
+    }
+}


### PR DESCRIPTION
## Summary
Automated fix for issue #643.

## Changes
- Fix #643: Add resetMovement() to clear polled WASD/sprint flags on arrest and respawn

Closes #643