### PR TITLE
Fix #646: getLargeStructures() filters on SMALL_STRUCTURE_THRESHOLD instead of LARGE_STRUCTURE_THRESHOLD

### DIFF
--- a/src/main/java/ragamuffin/building/StructureTracker.java
+++ b/src/main/java/ragamuffin/building/StructureTracker.java
@@ -170,7 +170,7 @@ public class StructureTracker {
     public List<Structure> getLargeStructures() {
         List<Structure> large = new ArrayList<>();
         for (Structure s : structures) {
-            if (s.getComplexity() >= SMALL_STRUCTURE_THRESHOLD) {
+            if (s.getComplexity() >= LARGE_STRUCTURE_THRESHOLD) {
                 large.add(s);
             }
         }


### PR DESCRIPTION
## Summary
Automated fix for issue #646.

## Changes
- Fix #646: getLargeStructures() now filters on LARGE_STRUCTURE_THRESHOLD (50) not SMALL_STRUCTURE_THRESHOLD (10)

Closes #646