### PR TITLE
Fix #678: Rework quest objectives to not require destroying quest origin building

### DIFF
--- a/src/main/java/ragamuffin/core/BuildingQuestRegistry.java
+++ b/src/main/java/ragamuffin/core/BuildingQuestRegistry.java
@@ -26,8 +26,8 @@ public class BuildingQuestRegistry {
 
         register(LandmarkType.GREGGS,
             new Quest("greggs_flour", "Greggs Baker",
-                "We've run out of pastry supplies. Get me 2 sausage rolls from anywhere and I'll owe you.",
-                ObjectiveType.COLLECT, Material.SAUSAGE_ROLL, 2,
+                "We're desperate — pop to Tesco and grab me 2 tins of beans. Baking emergency.",
+                ObjectiveType.COLLECT, Material.TIN_OF_BEANS, 2,
                 Material.STEAK_BAKE, 3));
 
         register(LandmarkType.OFF_LICENCE,
@@ -56,27 +56,27 @@ public class BuildingQuestRegistry {
 
         register(LandmarkType.BOOKIES,
             new Quest("bookies_scratchcard", "Coral Manager",
-                "Punters keep asking for scratch cards. Bring me 3 scratch cards and I'll split the winnings.",
-                ObjectiveType.COLLECT, Material.SCRATCH_CARD, 3,
+                "Punters keep asking for energy drinks. Grab me 3 from the off-licence and I'll sort you.",
+                ObjectiveType.COLLECT, Material.ENERGY_DRINK, 3,
                 Material.ENERGY_DRINK, 2));
 
         register(LandmarkType.KEBAB_SHOP,
             new Quest("sultan_kebab", "Sultan",
-                "We're out of kebab meat. Surprise me — bring me something edible.",
-                ObjectiveType.COLLECT, Material.CHIPS, 2,
+                "We're out of supplies. Grab me 2 tins of beans from the corner shop — improvising tonight.",
+                ObjectiveType.COLLECT, Material.TIN_OF_BEANS, 2,
                 Material.KEBAB, 2));
 
         register(LandmarkType.LAUNDERETTE,
             new Quest("launderette_powder", "Spotless Owner",
-                "I'm out of washing powder. Bring me some and I'll have your clothes fresh as a daisy.",
-                ObjectiveType.COLLECT, Material.WASHING_POWDER, 1,
-                Material.ANTIDEPRESSANTS, 1));
+                "Pipes are playing up. Pop to the fire station and make sure they know — I need a plumber.",
+                ObjectiveType.EXPLORE, null, 1,
+                LandmarkType.FIRE_STATION, Material.ANTIDEPRESSANTS, 1));
 
         register(LandmarkType.PUB,
             new Quest("pub_pint", "Barman",
-                "Landlord's doing a stock check. Bring in a couple of pints from the cellar, would you?",
-                ObjectiveType.COLLECT, Material.PINT, 2,
-                Material.CRISPS, 4));
+                "Need someone to check on my mate at the job centre. Go see if he's alright, would you?",
+                ObjectiveType.EXPLORE, null, 1,
+                LandmarkType.JOB_CENTRE, Material.CRISPS, 4));
 
         register(LandmarkType.PAWN_SHOP,
             new Quest("pawnshop_electronics", "Cash4Gold Manager",
@@ -86,27 +86,27 @@ public class BuildingQuestRegistry {
 
         register(LandmarkType.CHIPPY,
             new Quest("chippy_chips", "Tony",
-                "We've gone and run out of chips. Bring me 2 portions — yes, I know.",
-                ObjectiveType.COLLECT, Material.CHIPS, 2,
-                Material.KEBAB, 1));
+                "Oil delivery never showed. Pop to the builders merchant and see if they've got anything.",
+                ObjectiveType.EXPLORE, null, 1,
+                LandmarkType.BUILDERS_MERCHANT, Material.KEBAB, 1));
 
         register(LandmarkType.NEWSAGENT,
             new Quest("newsagent_paper", "Patel",
-                "My newspaper delivery never showed. Bring me 3 newspapers and I'll see you right.",
-                ObjectiveType.COLLECT, Material.NEWSPAPER, 3,
-                Material.PENNY, 6));
+                "My newspaper delivery never showed. Go check the library — might have some there.",
+                ObjectiveType.EXPLORE, null, 1,
+                LandmarkType.LIBRARY, Material.PENNY, 6));
 
         register(LandmarkType.GP_SURGERY,
             new Quest("surgery_meds", "Northfield Surgery Receptionist",
-                "We're running dangerously low on paracetamol. Can you bring some in?",
-                ObjectiveType.COLLECT, Material.PARACETAMOL, 2,
-                Material.ANTIDEPRESSANTS, 3));
+                "We need an emergency supply assessment. Can you check what the community centre has?",
+                ObjectiveType.EXPLORE, null, 1,
+                LandmarkType.COMMUNITY_CENTRE, Material.ANTIDEPRESSANTS, 3));
 
         register(LandmarkType.WETHERSPOONS,
             new Quest("spoons_pint", "Rusty Anchor Barman",
-                "Our pint deliveries are stuck in traffic. Bring 3 pints and drinks are on me.",
-                ObjectiveType.COLLECT, Material.PINT, 3,
-                Material.PERI_PERI_CHICKEN, 1));
+                "We've got a VIP punter asking for Nandos. Go check if they're open and come back.",
+                ObjectiveType.EXPLORE, null, 1,
+                LandmarkType.NANDOS, Material.PERI_PERI_CHICKEN, 1));
 
         register(LandmarkType.NANDOS,
             new Quest("nandos_chicken", "Nando's Manager",
@@ -116,15 +116,15 @@ public class BuildingQuestRegistry {
 
         register(LandmarkType.BARBER,
             new Quest("barber_clippers", "Kev",
-                "My clippers have gone walk-about. Find me a pair and I'll sort your hair for free.",
-                ObjectiveType.COLLECT, Material.HAIR_CLIPPERS, 1,
-                Material.PARACETAMOL, 2));
+                "Left me clippers at the pawn shop — the muppets took them. Go get 'em back.",
+                ObjectiveType.EXPLORE, null, 1,
+                LandmarkType.PAWN_SHOP, Material.PARACETAMOL, 2));
 
         register(LandmarkType.NAIL_SALON,
             new Quest("nails_polish", "Angel Nails",
-                "I'm out of my best colour — that deep red. Bring me a nail polish and I'll do your nails.",
-                ObjectiveType.COLLECT, Material.NAIL_POLISH, 1,
-                Material.ANTIDEPRESSANTS, 1));
+                "I'm waiting on a supplier. Pop to the cash converters and check if they've got anything.",
+                ObjectiveType.EXPLORE, null, 1,
+                LandmarkType.CASH_CONVERTER, Material.ANTIDEPRESSANTS, 1));
 
         register(LandmarkType.CORNER_SHOP,
             new Quest("cornershop_crisps", "Happy Shopper Owner",
@@ -222,6 +222,11 @@ public class BuildingQuestRegistry {
             }
             return "Still waiting on those " + quest.getRequiredCount() + " "
                 + materialName(quest.getRequiredMaterial()) + ". Don't let me down.";
+        }
+        if (quest.getType() == Quest.ObjectiveType.EXPLORE && quest.getTargetLandmark() != null) {
+            String name = quest.getTargetLandmark().getDisplayName();
+            if (name == null) name = quest.getTargetLandmark().name().toLowerCase().replace('_', ' ');
+            return "Not been yet? You need to head over to " + name + ". Off you go.";
         }
         return "You haven't finished the job yet.";
     }

--- a/src/main/java/ragamuffin/core/InteractionSystem.java
+++ b/src/main/java/ragamuffin/core/InteractionSystem.java
@@ -398,8 +398,9 @@ public class InteractionSystem {
             return BuildingQuestRegistry.getQuestOfferLine(quest);
         }
 
-        // Quest is active — check if player can complete it
-        if (inventory != null && quest.checkCompletion(inventory)) {
+        // Quest is active — check if player can complete it.
+        // EXPLORE quests don't need an inventory; COLLECT/DELIVER quests do.
+        if (quest.checkCompletion(inventory)) {
             boolean success = quest.complete(inventory);
             if (success) {
                 lastQuestCompleted = quest;
@@ -502,6 +503,26 @@ public class InteractionSystem {
      */
     public BuildingQuestRegistry getQuestRegistry() {
         return questRegistry;
+    }
+
+    /**
+     * Notify the quest system that the player has entered a landmark.
+     * Any active EXPLORE quests targeting this landmark will be marked as visited,
+     * making them completable when the player next speaks to the quest giver.
+     *
+     * @param landmarkType the landmark the player has just entered or reached
+     */
+    public void onPlayerEntersLandmark(ragamuffin.world.LandmarkType landmarkType) {
+        if (landmarkType == null) return;
+        for (ragamuffin.world.LandmarkType type : ragamuffin.world.LandmarkType.values()) {
+            Quest quest = questRegistry.getQuest(type);
+            if (quest == null) continue;
+            if (!quest.isActive() || quest.isCompleted()) continue;
+            if (quest.getType() == Quest.ObjectiveType.EXPLORE
+                    && landmarkType == quest.getTargetLandmark()) {
+                quest.markLocationVisited();
+            }
+        }
     }
 
     /**

--- a/src/main/java/ragamuffin/core/Quest.java
+++ b/src/main/java/ragamuffin/core/Quest.java
@@ -1,6 +1,7 @@
 package ragamuffin.core;
 
 import ragamuffin.building.Material;
+import ragamuffin.world.LandmarkType;
 
 /**
  * Represents a quest offered by a building NPC.
@@ -18,26 +19,37 @@ public class Quest {
     private final String giver;          // NPC / building name
     private final String description;   // What the player is asked to do
     private final ObjectiveType type;
-    private final Material requiredMaterial; // For COLLECT quests, null otherwise
+    private final Material requiredMaterial; // For COLLECT/DELIVER quests, null otherwise
     private final int requiredCount;         // How many items needed (1 for non-collect)
+    private final LandmarkType targetLandmark; // For EXPLORE/DELIVER quests, null otherwise
     private final Material reward;           // Item reward on completion
     private final int rewardCount;
     private boolean completed;
     private boolean active;
+    /** For EXPLORE quests: whether the player has visited the target landmark. */
+    private boolean locationVisited;
 
     public Quest(String id, String giver, String description,
                  ObjectiveType type, Material requiredMaterial, int requiredCount,
                  Material reward, int rewardCount) {
+        this(id, giver, description, type, requiredMaterial, requiredCount, null, reward, rewardCount);
+    }
+
+    public Quest(String id, String giver, String description,
+                 ObjectiveType type, Material requiredMaterial, int requiredCount,
+                 LandmarkType targetLandmark, Material reward, int rewardCount) {
         this.id = id;
         this.giver = giver;
         this.description = description;
         this.type = type;
         this.requiredMaterial = requiredMaterial;
         this.requiredCount = requiredCount;
+        this.targetLandmark = targetLandmark;
         this.reward = reward;
         this.rewardCount = rewardCount;
         this.completed = false;
         this.active = false;
+        this.locationVisited = false;
     }
 
     public String getId() { return id; }
@@ -46,36 +58,75 @@ public class Quest {
     public ObjectiveType getType() { return type; }
     public Material getRequiredMaterial() { return requiredMaterial; }
     public int getRequiredCount() { return requiredCount; }
+    public LandmarkType getTargetLandmark() { return targetLandmark; }
     public Material getReward() { return reward; }
     public int getRewardCount() { return rewardCount; }
     public boolean isCompleted() { return completed; }
     public boolean isActive() { return active; }
+    public boolean isLocationVisited() { return locationVisited; }
 
     public void setCompleted(boolean completed) { this.completed = completed; }
     public void setActive(boolean active) { this.active = active; }
 
     /**
-     * Check if the player's inventory satisfies this quest's objective.
+     * Mark the target landmark as visited. Used by EXPLORE quests.
+     * Has no effect on other quest types.
      */
-    public boolean checkCompletion(ragamuffin.building.Inventory inventory) {
-        if (completed) return true;
-        if (type == ObjectiveType.COLLECT && requiredMaterial != null) {
-            return inventory.getItemCount(requiredMaterial) >= requiredCount;
-        }
-        return false;
+    public void markLocationVisited() {
+        this.locationVisited = true;
     }
 
     /**
-     * Complete the quest: remove required items, award reward.
+     * Check if the quest's objective is satisfied.
+     * For EXPLORE quests, checks whether the target location has been visited
+     * (inventory is not needed and may be null).
+     * For COLLECT/DELIVER quests, checks the player's inventory.
+     */
+    public boolean checkCompletion(ragamuffin.building.Inventory inventory) {
+        if (completed) return true;
+        switch (type) {
+            case COLLECT:
+                if (requiredMaterial != null && inventory != null) {
+                    return inventory.getItemCount(requiredMaterial) >= requiredCount;
+                }
+                return false;
+            case DELIVER:
+                // DELIVER requires the player to have the items AND be at the target location.
+                // Completion is triggered externally (location check); here just verify items.
+                if (requiredMaterial != null && inventory != null) {
+                    return inventory.getItemCount(requiredMaterial) >= requiredCount;
+                }
+                return false;
+            case EXPLORE:
+                return locationVisited;
+            default:
+                return false;
+        }
+    }
+
+    /**
+     * Complete the quest: remove required items (for COLLECT/DELIVER), award reward.
+     * For EXPLORE quests, inventory may be null (no items are consumed or rewarded without one).
      * Returns true if completion was successful.
      */
     public boolean complete(ragamuffin.building.Inventory inventory) {
         if (completed) return false;
-        if (type == ObjectiveType.COLLECT && requiredMaterial != null) {
-            if (inventory.getItemCount(requiredMaterial) < requiredCount) return false;
-            inventory.removeItem(requiredMaterial, requiredCount);
+        switch (type) {
+            case COLLECT:
+            case DELIVER:
+                if (requiredMaterial != null) {
+                    if (inventory == null) return false;
+                    if (inventory.getItemCount(requiredMaterial) < requiredCount) return false;
+                    inventory.removeItem(requiredMaterial, requiredCount);
+                }
+                break;
+            case EXPLORE:
+                if (!locationVisited) return false;
+                break;
+            default:
+                break;
         }
-        if (reward != null) {
+        if (reward != null && inventory != null) {
             inventory.addItem(reward, rewardCount);
         }
         completed = true;

--- a/src/test/java/ragamuffin/core/Issue678QuestObjectiveReworkTest.java
+++ b/src/test/java/ragamuffin/core/Issue678QuestObjectiveReworkTest.java
@@ -1,0 +1,381 @@
+package ragamuffin.core;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import ragamuffin.building.Inventory;
+import ragamuffin.building.Material;
+import ragamuffin.core.Quest.ObjectiveType;
+import ragamuffin.world.LandmarkType;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Tests for Issue #678: Rework quest objectives to not require destroying the
+ * quest origin building.
+ *
+ * Previously, many quests asked players to collect items that only drop from
+ * breaking the quest-giver's own building (e.g. the Greggs quest wanted sausage
+ * rolls, which only drop from Greggs blocks).  These quests have been reworked
+ * to use either:
+ *   - COLLECT objectives requiring materials from *different* buildings, or
+ *   - EXPLORE objectives (visit a landmark) which never require destruction.
+ */
+class Issue678QuestObjectiveReworkTest {
+
+    private BuildingQuestRegistry registry;
+
+    @BeforeEach
+    void setUp() {
+        registry = new BuildingQuestRegistry();
+    }
+
+    // -----------------------------------------------------------------------
+    // 1. EXPLORE quest lifecycle
+    // -----------------------------------------------------------------------
+
+    /**
+     * An EXPLORE quest is not completable before the target location is visited.
+     */
+    @Test
+    void exploreQuest_notCompletableBeforeVisit() {
+        Quest quest = new Quest("explore_test", "Test NPC",
+                "Go visit the park.",
+                ObjectiveType.EXPLORE, null, 1,
+                LandmarkType.PARK, Material.CRISPS, 2);
+        quest.setActive(true);
+
+        Inventory inventory = new Inventory(9);
+        assertFalse(quest.checkCompletion(inventory),
+                "EXPLORE quest must not be completable before visiting the target");
+    }
+
+    /**
+     * An EXPLORE quest becomes completable after markLocationVisited().
+     */
+    @Test
+    void exploreQuest_completableAfterVisit() {
+        Quest quest = new Quest("explore_test", "Test NPC",
+                "Go visit the park.",
+                ObjectiveType.EXPLORE, null, 1,
+                LandmarkType.PARK, Material.CRISPS, 2);
+        quest.setActive(true);
+
+        quest.markLocationVisited();
+
+        Inventory inventory = new Inventory(9);
+        assertTrue(quest.checkCompletion(inventory),
+                "EXPLORE quest must be completable after the target is visited");
+    }
+
+    /**
+     * Completing an EXPLORE quest awards the reward and marks it done.
+     */
+    @Test
+    void exploreQuest_completionAwardsRewardAndMarksDone() {
+        Quest quest = new Quest("explore_test", "Test NPC",
+                "Go visit the park.",
+                ObjectiveType.EXPLORE, null, 1,
+                LandmarkType.PARK, Material.CRISPS, 2);
+        quest.setActive(true);
+        quest.markLocationVisited();
+
+        Inventory inventory = new Inventory(9);
+        boolean success = quest.complete(inventory);
+
+        assertTrue(success, "complete() should succeed for a visited EXPLORE quest");
+        assertTrue(quest.isCompleted(), "Quest must be marked completed");
+        assertFalse(quest.isActive(), "Quest must no longer be active");
+        assertEquals(2, inventory.getItemCount(Material.CRISPS),
+                "Reward must be added to inventory");
+    }
+
+    /**
+     * Completing an EXPLORE quest without an inventory (null) still marks it done
+     * but awards no item (graceful degradation).
+     */
+    @Test
+    void exploreQuest_completionWithNullInventoryMarksDone() {
+        Quest quest = new Quest("explore_test", "Test NPC",
+                "Go visit the park.",
+                ObjectiveType.EXPLORE, null, 1,
+                LandmarkType.PARK, Material.CRISPS, 2);
+        quest.setActive(true);
+        quest.markLocationVisited();
+
+        boolean success = quest.complete(null);
+
+        assertTrue(success, "complete(null) should succeed for a visited EXPLORE quest");
+        assertTrue(quest.isCompleted(), "Quest must be marked completed");
+    }
+
+    // -----------------------------------------------------------------------
+    // 2. InteractionSystem.onPlayerEntersLandmark()
+    // -----------------------------------------------------------------------
+
+    /**
+     * When the player enters the target landmark for an active EXPLORE quest,
+     * the quest should be marked as visited.
+     */
+    @Test
+    void onPlayerEntersLandmark_marksExploreQuestVisited() {
+        InteractionSystem system = new InteractionSystem();
+
+        // Activate the PUB quest (EXPLORE: visit JOB_CENTRE)
+        Quest pubQuest = system.getQuestRegistry().getQuest(LandmarkType.PUB);
+        assertNotNull(pubQuest, "PUB quest must exist");
+        assertEquals(ObjectiveType.EXPLORE, pubQuest.getType(),
+                "PUB quest must be an EXPLORE quest after the rework");
+        pubQuest.setActive(true);
+
+        assertFalse(pubQuest.isLocationVisited(), "Location must not be visited yet");
+
+        system.onPlayerEntersLandmark(pubQuest.getTargetLandmark());
+
+        assertTrue(pubQuest.isLocationVisited(),
+                "Location must be marked visited after onPlayerEntersLandmark()");
+    }
+
+    /**
+     * onPlayerEntersLandmark() should not affect quests for a *different* target.
+     */
+    @Test
+    void onPlayerEntersLandmark_doesNotAffectOtherExploreQuests() {
+        InteractionSystem system = new InteractionSystem();
+
+        Quest pubQuest = system.getQuestRegistry().getQuest(LandmarkType.PUB);
+        Quest launderetteQuest = system.getQuestRegistry().getQuest(LandmarkType.LAUNDERETTE);
+        assertNotNull(pubQuest);
+        assertNotNull(launderetteQuest);
+        pubQuest.setActive(true);
+        launderetteQuest.setActive(true);
+
+        // Enter the PUB quest's target — should NOT affect launderette quest
+        system.onPlayerEntersLandmark(pubQuest.getTargetLandmark());
+
+        assertFalse(launderetteQuest.isLocationVisited(),
+                "Visiting PUB's target must not mark LAUNDERETTE quest as visited");
+    }
+
+    /**
+     * onPlayerEntersLandmark() should not mark an inactive quest as visited.
+     */
+    @Test
+    void onPlayerEntersLandmark_ignoresInactiveQuests() {
+        InteractionSystem system = new InteractionSystem();
+
+        Quest pubQuest = system.getQuestRegistry().getQuest(LandmarkType.PUB);
+        assertNotNull(pubQuest);
+        // Do NOT activate the quest
+        assertFalse(pubQuest.isActive());
+
+        system.onPlayerEntersLandmark(pubQuest.getTargetLandmark());
+
+        assertFalse(pubQuest.isLocationVisited(),
+                "Inactive quest must not be marked visited");
+    }
+
+    // -----------------------------------------------------------------------
+    // 3. Specific formerly-self-destructive quests are now reworked
+    // -----------------------------------------------------------------------
+
+    /**
+     * The GREGGS quest must no longer require sausage rolls (which only drop
+     * from Greggs blocks).
+     */
+    @Test
+    void greggsQuest_doesNotRequireSausageRoll() {
+        Quest q = registry.getQuest(LandmarkType.GREGGS);
+        assertNotNull(q);
+        assertNotEquals(Material.SAUSAGE_ROLL, q.getRequiredMaterial(),
+                "GREGGS quest must not require sausage rolls (they only drop from Greggs blocks)");
+    }
+
+    /**
+     * The PUB quest must be an EXPLORE quest (no longer requires pints from pub blocks).
+     */
+    @Test
+    void pubQuest_isExploreType() {
+        Quest q = registry.getQuest(LandmarkType.PUB);
+        assertNotNull(q);
+        assertEquals(ObjectiveType.EXPLORE, q.getType(),
+                "PUB quest must be EXPLORE type after rework");
+        assertNotNull(q.getTargetLandmark(),
+                "PUB EXPLORE quest must have a target landmark");
+    }
+
+    /**
+     * The WETHERSPOONS quest must be an EXPLORE quest (no longer requires pints).
+     */
+    @Test
+    void wetherspoonsQuest_isExploreType() {
+        Quest q = registry.getQuest(LandmarkType.WETHERSPOONS);
+        assertNotNull(q);
+        assertEquals(ObjectiveType.EXPLORE, q.getType(),
+                "WETHERSPOONS quest must be EXPLORE type after rework");
+        assertNotNull(q.getTargetLandmark(),
+                "WETHERSPOONS EXPLORE quest must have a target landmark");
+    }
+
+    /**
+     * The CHIPPY quest must be an EXPLORE quest (no longer requires chips from chippy blocks).
+     */
+    @Test
+    void chippyQuest_isExploreType() {
+        Quest q = registry.getQuest(LandmarkType.CHIPPY);
+        assertNotNull(q);
+        assertEquals(ObjectiveType.EXPLORE, q.getType(),
+                "CHIPPY quest must be EXPLORE type after rework");
+    }
+
+    /**
+     * The NEWSAGENT quest must be an EXPLORE quest (no longer requires newspapers from newsagent blocks).
+     */
+    @Test
+    void newsagentQuest_isExploreType() {
+        Quest q = registry.getQuest(LandmarkType.NEWSAGENT);
+        assertNotNull(q);
+        assertEquals(ObjectiveType.EXPLORE, q.getType(),
+                "NEWSAGENT quest must be EXPLORE type after rework");
+    }
+
+    /**
+     * The LAUNDERETTE quest must be an EXPLORE quest (no longer requires washing powder from launderette blocks).
+     */
+    @Test
+    void launderetteQuest_isExploreType() {
+        Quest q = registry.getQuest(LandmarkType.LAUNDERETTE);
+        assertNotNull(q);
+        assertEquals(ObjectiveType.EXPLORE, q.getType(),
+                "LAUNDERETTE quest must be EXPLORE type after rework");
+    }
+
+    /**
+     * The GP_SURGERY quest must be an EXPLORE quest (no longer requires paracetamol from surgery blocks).
+     */
+    @Test
+    void gpSurgeryQuest_isExploreType() {
+        Quest q = registry.getQuest(LandmarkType.GP_SURGERY);
+        assertNotNull(q);
+        assertEquals(ObjectiveType.EXPLORE, q.getType(),
+                "GP_SURGERY quest must be EXPLORE type after rework");
+    }
+
+    /**
+     * The BARBER quest must be an EXPLORE quest (no longer requires clippers from barber blocks).
+     */
+    @Test
+    void barberQuest_isExploreType() {
+        Quest q = registry.getQuest(LandmarkType.BARBER);
+        assertNotNull(q);
+        assertEquals(ObjectiveType.EXPLORE, q.getType(),
+                "BARBER quest must be EXPLORE type after rework");
+    }
+
+    /**
+     * The NAIL_SALON quest must be an EXPLORE quest.
+     */
+    @Test
+    void nailSalonQuest_isExploreType() {
+        Quest q = registry.getQuest(LandmarkType.NAIL_SALON);
+        assertNotNull(q);
+        assertEquals(ObjectiveType.EXPLORE, q.getType(),
+                "NAIL_SALON quest must be EXPLORE type after rework");
+    }
+
+    /**
+     * The BOOKIES quest must not require scratch cards (which only drop from bookies blocks).
+     */
+    @Test
+    void bookiesQuest_doesNotRequireScratchCards() {
+        Quest q = registry.getQuest(LandmarkType.BOOKIES);
+        assertNotNull(q);
+        assertNotEquals(Material.SCRATCH_CARD, q.getRequiredMaterial(),
+                "BOOKIES quest must not require scratch cards (they only drop from Bookies blocks)");
+    }
+
+    // -----------------------------------------------------------------------
+    // 4. EXPLORE quests all have a valid target landmark
+    // -----------------------------------------------------------------------
+
+    /**
+     * Every EXPLORE quest in the registry must have a non-null target landmark.
+     */
+    @Test
+    void allExploreQuests_haveTargetLandmark() {
+        for (LandmarkType type : LandmarkType.values()) {
+            Quest q = registry.getQuest(type);
+            if (q == null) continue;
+            if (q.getType() == ObjectiveType.EXPLORE) {
+                assertNotNull(q.getTargetLandmark(),
+                        "EXPLORE quest for " + type + " must have a target landmark");
+            }
+        }
+    }
+
+    /**
+     * Every EXPLORE quest's target landmark must be different from its origin landmark.
+     * (The quest must not send the player to the same building that gave the quest.)
+     */
+    @Test
+    void allExploreQuests_targetIsDifferentFromOrigin() {
+        for (LandmarkType origin : LandmarkType.values()) {
+            Quest q = registry.getQuest(origin);
+            if (q == null) continue;
+            if (q.getType() == ObjectiveType.EXPLORE && q.getTargetLandmark() != null) {
+                assertNotEquals(origin, q.getTargetLandmark(),
+                        "EXPLORE quest for " + origin + " must target a different landmark, not itself");
+            }
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // 5. Reminder lines for EXPLORE quests are non-empty
+    // -----------------------------------------------------------------------
+
+    /**
+     * getQuestReminderLine() for an EXPLORE quest must return a non-blank message
+     * that references the target location.
+     */
+    @Test
+    void exploreQuestReminderLine_isNonBlankAndReferencesTarget() {
+        Quest pubQuest = registry.getQuest(LandmarkType.PUB);
+        assertNotNull(pubQuest);
+        pubQuest.setActive(true);
+
+        String reminder = BuildingQuestRegistry.getQuestReminderLine(pubQuest, null);
+
+        assertNotNull(reminder, "Reminder must not be null");
+        assertFalse(reminder.isBlank(), "Reminder must not be blank");
+        // The reminder should mention the target location in some form
+        assertNotEquals("You haven't finished the job yet.", reminder,
+                "EXPLORE quest reminder must be specific, not the generic fallback");
+    }
+
+    // -----------------------------------------------------------------------
+    // 6. COLLECT quests that were reworked are completable without destruction
+    // -----------------------------------------------------------------------
+
+    /**
+     * The KEBAB_SHOP quest now asks for TIN_OF_BEANS (from Tesco/corner shop),
+     * and must be completable by providing those items without touching kebab shop blocks.
+     */
+    @Test
+    void kebabShopQuest_completableWithTinOfBeans() {
+        Quest q = registry.getQuest(LandmarkType.KEBAB_SHOP);
+        assertNotNull(q);
+        assertEquals(ObjectiveType.COLLECT, q.getType(),
+                "KEBAB_SHOP quest should be COLLECT type");
+        assertEquals(Material.TIN_OF_BEANS, q.getRequiredMaterial(),
+                "KEBAB_SHOP quest should now require tin of beans");
+
+        q.setActive(true);
+        Inventory inv = new Inventory(9);
+        inv.addItem(Material.TIN_OF_BEANS, q.getRequiredCount());
+
+        assertTrue(q.checkCompletion(inv),
+                "KEBAB_SHOP quest must be completable by providing tin of beans");
+    }
+}


### PR DESCRIPTION
## Summary
Automated fix for issue #678.

## Changes
- Fix #678: Rework quest objectives to not require destroying quest origin building

Closes #678