### PR TITLE
Fix #725: Fix: Player can sprint at 0% energy

### DIFF
--- a/src/main/java/ragamuffin/core/RagamuffinGame.java
+++ b/src/main/java/ragamuffin/core/RagamuffinGame.java
@@ -2272,7 +2272,7 @@ public class RagamuffinGame extends ApplicationAdapter {
             if (tmpMoveDir.len2() > 0) {
                 tmpMoveDir.nor();
             }
-            moveSpeed = inputHandler.isSprintHeld() ? Player.SPRINT_SPEED : Player.MOVE_SPEED;
+            moveSpeed = (inputHandler.isSprintHeld() && player.canSprint()) ? Player.SPRINT_SPEED : Player.MOVE_SPEED;
         }
         world.moveWithCollision(player, tmpMoveDir.x, 0, tmpMoveDir.z, delta, moveSpeed);
 

--- a/src/main/java/ragamuffin/entity/Player.java
+++ b/src/main/java/ragamuffin/entity/Player.java
@@ -576,6 +576,14 @@ public class Player {
     }
 
     /**
+     * Whether the player has enough energy to sprint.
+     * Requires at least 1 energy to prevent sprinting on empty stamina.
+     */
+    public boolean canSprint() {
+        return energy > 0;
+    }
+
+    /**
      * Whether the dodge cooldown has expired and a new dodge is available.
      */
     public boolean canDodge() {

--- a/src/test/java/ragamuffin/entity/PlayerTest.java
+++ b/src/test/java/ragamuffin/entity/PlayerTest.java
@@ -293,6 +293,22 @@ class PlayerTest {
     }
 
     @Test
+    void energyExhaustedPlayerCannotSprint() {
+        Player player = new Player(0, 0, 0);
+        player.setEnergy(0);
+        assertFalse(player.canSprint(), "Player with 0 energy should not be able to sprint");
+    }
+
+    @Test
+    void playerWithEnergyCanSprint() {
+        Player player = new Player(0, 0, 0);
+        assertTrue(player.canSprint(), "Player with full energy should be able to sprint");
+
+        player.setEnergy(1);
+        assertTrue(player.canSprint(), "Player with exactly 1 energy should be able to sprint");
+    }
+
+    @Test
     void energyExhaustedPlayerCannotDodge() {
         Player player = new Player(0, 0, 0);
         player.setEnergy(0);


### PR DESCRIPTION
## Summary
Automated fix for issue #725.

## Changes
- Fix #725: Disable sprinting when energy is depleted

Closes #725