### PR TITLE
Fix #727: Fix menu text size and rendering quality

### DIFF
--- a/src/main/java/ragamuffin/core/RagamuffinGame.java
+++ b/src/main/java/ragamuffin/core/RagamuffinGame.java
@@ -4,6 +4,7 @@ import com.badlogic.gdx.ApplicationAdapter;
 import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.graphics.GL20;
 import com.badlogic.gdx.graphics.PerspectiveCamera;
+import com.badlogic.gdx.graphics.Texture;
 import com.badlogic.gdx.graphics.g2d.BitmapFont;
 import com.badlogic.gdx.graphics.g2d.SpriteBatch;
 import com.badlogic.gdx.graphics.g3d.Environment;
@@ -231,6 +232,9 @@ public class RagamuffinGame extends ApplicationAdapter {
         spriteBatch = new SpriteBatch();
         shapeRenderer = new ShapeRenderer();
         font = new BitmapFont();
+        // Fix #727: enable linear filtering so scaled-up menu text renders cleanly
+        // instead of appearing pixelated/garbled when drawn at non-native sizes.
+        font.getRegion().getTexture().setFilter(Texture.TextureFilter.Linear, Texture.TextureFilter.Linear);
         font.getData().setScale(1.2f);
 
         // Setup input (so user can interact with the loading screen)


### PR DESCRIPTION
## Summary
Automated fix for issue #727.

## Changes
- Fix #727: enable linear texture filtering on BitmapFont for readable menu text

Closes #727