### PR TITLE
Fix #1045: Add Northfield Council Flats — Lift, Knock-On Economy & Eviction Quest

### DIFF
--- a/src/main/java/ragamuffin/building/Material.java
+++ b/src/main/java/ragamuffin/building/Material.java
@@ -2170,7 +2170,22 @@ public enum Material {
      * Police nearby adds SUSPICIOUS_PACKAGE suspicion to CriminalRecord.
      * Tooltip: "Don't open it. Seriously."
      */
-    MARCHETTI_PACKAGE("Marchetti Package");
+    MARCHETTI_PACKAGE("Marchetti Package"),
+
+    // ── Issue #1045: Northfield Council Flats ────────────────────────────────
+
+    /**
+     * Parcel Delivery — a parcel collected from the Post Office for a FLAT_RESIDENT
+     * side-quest. Delivering it earns 3 COIN. Single use; consumed on delivery.
+     */
+    PARCEL_DELIVERY("Parcel Delivery"),
+
+    /**
+     * Master Key — earned by completing Donna's eviction quest chain (tower 1).
+     * Opens any FLAT_DOOR_PROP in tower 1 without knocking.
+     * Tooltip: "Opens every door on the estate. Don't lose it."
+     */
+    MASTER_KEY("Master Key");
 
     private final String displayName;
 

--- a/src/main/java/ragamuffin/entity/NPCType.java
+++ b/src/main/java/ragamuffin/entity/NPCType.java
@@ -1042,7 +1042,20 @@ public enum NPCType {
      *         "Oi — what d'you think you're doing?" /
      *         "Cheers — the lads have been struggling."
      */
-    WATCH_COMMANDER(50f, 8f, 2.0f, false);
+    WATCH_COMMANDER(50f, 8f, 2.0f, false),
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Issue #1045: Northfield Council Flats NPCs
+    // ─────────────────────────────────────────────────────────────────────────
+
+    /**
+     * Flat Resident — a council estate resident NPC.
+     * Emerges from their flat 06:00–23:00 and wanders between the lobby,
+     * corner shop, and park. Returns home at 23:00.
+     * If the lift is broken, mutters "That bloody lift!"
+     * Passive; never hostile unless provoked.
+     */
+    FLAT_RESIDENT(20f, 0f, 0f, false);
 
     private final float maxHealth;
     private final float attackDamage;   // Damage per hit to player


### PR DESCRIPTION
## Summary
Automated fix for issue #1045.

## Changes
- Fix #1045: automated fix

Closes #1045