### PR TITLE
Fix #1087: Add Northfield Nightclub — The Vaults, the Bouncer Economy & the 2am Chaos

### DIFF
--- a/src/main/java/ragamuffin/building/Material.java
+++ b/src/main/java/ragamuffin/building/Material.java
@@ -2512,7 +2512,64 @@ public enum Material {
      * time (session cost reduced) for 7 in-game days.
      * Tooltip: "Five quid for a card that saves you 20p. Asif's no mug."
      */
-    CYBERNET_MEMBERSHIP_CARD("Cybernet Membership Card");
+    CYBERNET_MEMBERSHIP_CARD("Cybernet Membership Card"),
+
+    // ── Issue #1087: The Vaults Nightclub ─────────────────────────────────────
+
+    /**
+     * Alcopop — a sugary bottled drink sold at The Vaults bar for 1 COIN.
+     * DrunkenessLevel +1 on consumption.
+     */
+    ALCOPOP("Alcopop"),
+
+    /**
+     * Double Vodka — strong spirit sold at The Vaults bar for 1 COIN.
+     * DrunkenessLevel +2 on consumption (great value).
+     */
+    DOUBLE_VODKA("Double Vodka"),
+
+    /**
+     * Pills — sold by The Dealer in the club toilets (4 COIN ×2).
+     * Effect: DrunkenessLevel −1, movement speed +20% for 5 in-game minutes,
+     * then DrunkenessLevel +2 crash.
+     * Purchase triggers 10% undercover bust check.
+     */
+    PILLS("Pills"),
+
+    /**
+     * Faction Pass — grants free VIP entry to The Vaults, skipping the queue.
+     * Obtainable by completing a Marchetti mission outside the club.
+     * Big Dave tips his chin when you show it.
+     */
+    FACTION_PASS("Faction Pass"),
+
+    /**
+     * Phone Tracker Item — given by Tony Marchetti for the tracker side mission.
+     * One-use; must be pickpocketed into a named STREET_LADS NPC's jacket.
+     * On success: MARCHETTI_CREW Respect +15, 10 COIN reward.
+     */
+    PHONE_TRACKER_ITEM("Phone Tracker"),
+
+    /**
+     * Lost Wallet — drops from a random NPC at closing time chaos (02:45).
+     * Contains 3–8 COIN (revealed on E). Can be returned to the police station
+     * for Notoriety −2, or kept for the cash.
+     */
+    LOST_WALLET("Lost Wallet"),
+
+    /**
+     * Cigarettes — sold from the CIGARETTE_MACHINE_PROP (5× for 2 COIN).
+     * Smoking one (E while selected) reduces DrunkenessLevel −1
+     * but adds Notoriety +1 (anti-social behaviour).
+     */
+    CIGARETTES("Cigarettes"),
+
+    /**
+     * Club Wristband — issued on entry to The Vaults.
+     * Required to re-enter the same night without paying again.
+     * Consumed on exit if not re-entering.
+     */
+    CLUB_WRISTBAND("Club Wristband");
 
     private final String displayName;
 

--- a/src/main/java/ragamuffin/entity/NPCType.java
+++ b/src/main/java/ragamuffin/entity/NPCType.java
@@ -1163,7 +1163,41 @@ public enum NPCType {
      * If tipped (energy drink received): seeds LOCAL_EVENT rumour.
      * Speech: "Cheers mate." / "I'll put the word out." / "Don't tell my uncle."
      */
-    INTERNET_CAFE_ASSISTANT(20f, 0f, 0f, false);
+    INTERNET_CAFE_ASSISTANT(20f, 0f, 0f, false),
+
+    // ── Issue #1087: The Vaults Nightclub ─────────────────────────────────────
+
+    /**
+     * DJ Mikey — energetic DJ on the decks at The Vaults nightclub.
+     * Present Thu–Sun 22:00–03:00. Comments on crowd size.
+     * At crowd {@literal <} 5: "It's dead in here, man."
+     * At crowd ≥ 15: "This place is jumping!" — seeds LOCAL_EVENT rumour.
+     * When active, {@code RaveSystem.isVaultsDjPresent()} returns true.
+     */
+    DJ(20f, 0f, 0f, false),
+
+    /**
+     * Chantelle — barmaid at The Vaults nightclub. Quick, no-nonsense.
+     * Refuses service when player DrunkenessLevel ≥ 4:
+     * "You've had enough, babe."
+     * Present Thu–Sun 22:00–03:00.
+     */
+    BARMAID(20f, 0f, 0f, false),
+
+    /**
+     * The Dealer — drug dealer who loiters in the club toilets 22:00–02:30.
+     * Sells PILLS ×2 for 4 COIN. Flees on police arrival.
+     * Each purchase triggers a 10% undercover bust check.
+     */
+    DEALER(20f, 0f, 0f, false),
+
+    /**
+     * Tony Marchetti — senior crime boss. Present at The Vaults VIP booth
+     * Fri–Sat 23:00–01:00 at MARCHETTI_CREW Respect ≥ 50.
+     * Offers the phone-tracker side mission.
+     * Also used in other Marchetti faction contexts.
+     */
+    CRIME_BOSS(40f, 8f, 2.0f, false);
 
     private final float maxHealth;
     private final float attackDamage;   // Damage per hit to player

--- a/src/main/java/ragamuffin/world/LandmarkType.java
+++ b/src/main/java/ragamuffin/world/LandmarkType.java
@@ -433,7 +433,21 @@ public enum LandmarkType {
      * WantedSystem, CriminalRecord, DisguiseSystem, NeighbourhoodSystem,
      * WeatherSystem, NoiseSystem, WitnessSystem, RumourNetwork, AchievementSystem.
      */
-    INTERNET_CAFE;
+    INTERNET_CAFE,
+
+    /**
+     * The Vaults — converted railway arch nightclub at the edge of the high
+     * street near the Wetherspoons. Open Thu–Sun 22:00–03:00. Entry: 3 COIN
+     * (Big Dave the BOUNCER on the door). Main floor: dancefloor, bar, DJ booth.
+     * Lower level: VIP booths and fire exit.
+     *
+     * <p>Integrates with NightclubSystem, TaxiSystem, KebabVanSystem, RaveSystem,
+     * MCBattleSystem, StreetSkillSystem, FactionSystem, NotorietySystem, WantedSystem,
+     * CriminalRecord, DisguiseSystem, RumourNetwork, NeighbourhoodSystem,
+     * WeatherSystem, NoiseSystem, NeighbourhoodWatchSystem, WitnessSystem,
+     * AchievementSystem.
+     */
+    NIGHTCLUB;
 
     /**
      * Returns the display name shown on the building's sign.
@@ -512,6 +526,7 @@ public enum LandmarkType {
             case PET_SHOP:              return "Paws 'n' Claws";
             case VET_SURGERY:           return "Northfield Vets";
             case INTERNET_CAFE:         return "Cybernet";
+            case NIGHTCLUB:             return "The Vaults";
             default:                    return null; // No sign for parks, houses, etc.
         }
     }


### PR DESCRIPTION
## Summary
Automated fix for issue #1087.

## Changes
- Fix #1087: automated fix

Closes #1087