### PR TITLE
Fix #1151: Add Northfield Sporting & Social Club — Darts, Quiz Nights, the Members' Bar & the Protection Handover

### DIFF
--- a/src/main/java/ragamuffin/building/Material.java
+++ b/src/main/java/ragamuffin/building/Material.java
@@ -3655,7 +3655,32 @@ public enum Material {
      * for 5 COIN/week. Grants access and allows use of GARAGE_SHELF_PROP.
      * Tooltip: "It's yours. For now. Keep up the payments."
      */
-    GARAGE_KEY_7("Garage Key 7");
+    GARAGE_KEY_7("Garage Key 7"),
+
+    // ── Issue #1151: Northfield Sporting & Social Club ────────────────────────
+
+    /**
+     * Club Membership Card — sold by Ron (SOCIAL_CLUB_STEWARD) for 5 COIN.
+     * Grants access to the main bar, members' pricing on drinks, and all activities.
+     * Required for darts challenges, quiz entry, and back-room pontoon.
+     * Tooltip: "Membership has its privileges. Mostly cheaper beer."
+     */
+    CLUB_MEMBERSHIP_CARD("Club Membership Card"),
+
+    /**
+     * Darts Set — a set of steel-tip darts, awarded when beating Brian in a 501 match.
+     * Equipped to hotbar; improves darts accuracy by +1 tier when used at DARTBOARD_PROP.
+     * Tooltip: "Tungsten tips. Proper flights. You know what you're doing."
+     */
+    DARTS_SET("Darts Set"),
+
+    /**
+     * Quiz Answer Sheet — Maureen's master answer sheet for Thursday Quiz Night.
+     * Can be stolen from NOTICE_BOARD_PROP at 19:00–19:30 (before Maureen collects it).
+     * Using it during the quiz guarantees correct answers but has 30% chance of detection.
+     * Tooltip: "Capital of Peru? Lima. Everyone always forgets Lima."
+     */
+    QUIZ_ANSWER_SHEET("Quiz Answer Sheet");
 
     private final String displayName;
 
@@ -4579,6 +4604,14 @@ public enum Material {
             case GARAGE_KEY_7:            return cs(0.78f, 0.65f, 0.20f,  // Brass key
                                                     0.55f, 0.45f, 0.10f); // Darker brass
 
+            // Issue #1151: Northfield Sporting & Social Club
+            case CLUB_MEMBERSHIP_CARD:    return cs(0.10f, 0.30f, 0.70f,  // Club blue card
+                                                    0.05f, 0.15f, 0.45f); // Dark navy
+            case DARTS_SET:               return cs(0.50f, 0.50f, 0.52f,  // Steel grey
+                                                    0.25f, 0.25f, 0.28f); // Dark metal
+            case QUIZ_ANSWER_SHEET:       return cs(0.95f, 0.95f, 0.88f,  // Off-white paper
+                                                    0.20f, 0.20f, 0.60f); // Blue ink lines
+
             default:             return c(0.5f, 0.5f, 0.5f);
         }
     }
@@ -5035,6 +5068,10 @@ public enum Material {
             case BURNER_PHONE:
             case PIGEON_FEED_BAG:
             case GARAGE_KEY_7:
+            // Issue #1151: Northfield Sporting & Social Club — not block items
+            case CLUB_MEMBERSHIP_CARD:
+            case DARTS_SET:
+            case QUIZ_ANSWER_SHEET:
                 return false;
             default:
                 return true;
@@ -5992,6 +6029,14 @@ public enum Material {
                 return IconShape.BOX;         // large sack
             case GARAGE_KEY_7:
                 return IconShape.TOOL;        // small Yale key
+
+            // Issue #1151: Northfield Sporting & Social Club
+            case CLUB_MEMBERSHIP_CARD:
+                return IconShape.CARD;        // laminated membership card
+            case DARTS_SET:
+                return IconShape.TOOL;        // steel-tip darts
+            case QUIZ_ANSWER_SHEET:
+                return IconShape.FLAT_PAPER;  // answer sheet
 
             default:
                 return IconShape.BOX;

--- a/src/main/java/ragamuffin/entity/NPCType.java
+++ b/src/main/java/ragamuffin/entity/NPCType.java
@@ -1689,7 +1689,46 @@ public enum NPCType {
      *         "That'll be a quid, mate." /
      *         "You're alright, come in."
      */
-    GARAGE_BAND_DOORMAN(30f, 0f, 0f, false);
+    GARAGE_BAND_DOORMAN(30f, 0f, 0f, false),
+
+    // ── Issue #1151: Northfield Sporting & Social Club ────────────────────────
+
+    /**
+     * Ron — steward of the Northfield Sporting &amp; Social Club.
+     * Sells CLUB_MEMBERSHIP_CARD for 5 COIN. Mans the front desk Mon–Sat 11:00–23:00.
+     * Blocks non-members from the main bar. Knows about the protection arrangement but
+     * stays quiet unless the player has Respect ≥ 50 with STREET_LADS faction.
+     * Speech: "Members only, mate." / "Fiver for the card." /
+     *         "Ron's the name. I just work here." / "I don't want any trouble."
+     */
+    SOCIAL_CLUB_STEWARD(30f, 3f, 2.0f, false),
+
+    /**
+     * Maureen — quiz host at the Thursday Quiz Night (19:30–22:00).
+     * Carries the QUIZ_ANSWER_SHEET which can be stolen from the notice board.
+     * Announces rounds, reads questions, and tallies scores.
+     * Speech: "Right, question one..." / "No phones!" /
+     *         "Put that away, I can see you." / "And the winner is..."
+     */
+    QUIZ_HOST(25f, 0f, 0f, false),
+
+    /**
+     * Club Regular — a rank-and-file member of the social club.
+     * Attends darts nights, quiz nights, and general socialising.
+     * On Fri/Sat 19:00–23:00, one will issue a darts wager challenge.
+     * Speech: "You any good at darts?" / "Double top for the win." /
+     *         "I've been coming here thirty years." / "Best bitter in Northfield."
+     */
+    CLUB_REGULAR(25f, 2f, 2.0f, false),
+
+    /**
+     * Tommy Marchetti's enforcer — collects the 20 COIN protection envelope Mon 20:00–21:30.
+     * Becomes hostile if the player steals the envelope or grasses to the police.
+     * At HOSTILE state: attacks on sight; triggers Wanted +3 if player is spotted.
+     * Speech: "Tommy sends his regards." / "Is it ready?" /
+     *         "Don't make this difficult." / "You've made a very big mistake."
+     */
+    MARCHETTI_ENFORCER(60f, 14f, 1.8f, false);
 
     private final float maxHealth;
     private final float attackDamage;   // Damage per hit to player

--- a/src/main/java/ragamuffin/ui/AchievementType.java
+++ b/src/main/java/ragamuffin/ui/AchievementType.java
@@ -3130,6 +3130,58 @@ public enum AchievementType {
         "Lock-Up Landlord",
         "5 COIN a week. It's not much. But it's yours. For now.",
         1
+    ),
+
+    // ── Issue #1151: Northfield Sporting & Social Club ────────────────────────
+
+    /**
+     * Awarded when the player beats Brian the resident darts pro in a 501 match.
+     * Requires full 501 game completed at DARTBOARD_PROP with a double-out finish.
+     */
+    TREBLE_TOP(
+        "Treble Top",
+        "Beat Brian at darts. He's been club champion for eleven years. Not any more.",
+        1
+    ),
+
+    /**
+     * Awarded when the player wins Thursday Quiz Night with the highest score.
+     * Must enter (1 COIN), complete all 8 rounds, and finish top of the leaderboard.
+     */
+    PONTOON_KING(
+        "Pontoon King",
+        "Cleaned out three Marchetti boys at the back-room card table. Diplomatically unwise. Financially excellent.",
+        1
+    ),
+
+    /**
+     * Awarded when the player steals the protection envelope before Tommy's enforcer arrives.
+     * Must grab the envelope from PROTECTION_ENVELOPE_PROP during the 19:55–20:00 window.
+     */
+    ENVELOPE_THIEF(
+        "Envelope Thief",
+        "Nicked Tommy Marchetti's protection money. The consequences will be significant.",
+        1
+    ),
+
+    /**
+     * Awarded when the player pays Ron's debt (requires STREET_LADS Respect >= 50)
+     * and buys a round for the whole club. A genuine pillar of the community. Almost.
+     */
+    SOCIAL_PILLAR(
+        "Social Pillar",
+        "Paid Ron's debt and bought the house a round. You're basically a local celebrity now.",
+        1
+    ),
+
+    /**
+     * Awarded when the player grasses Tommy Marchetti to the police station,
+     * triggering the sting operation that gets him arrested.
+     */
+    GRASSED_UP(
+        "Grassed Up",
+        "Tipped off the police about Tommy's collection. 40% chance they find out it was you. Good luck.",
+        1
     );
 
     private final String name;

--- a/src/main/java/ragamuffin/world/PropType.java
+++ b/src/main/java/ragamuffin/world/PropType.java
@@ -2146,7 +2146,46 @@ public enum PropType {
      * Pigeon Coop Prop — a wooden pigeon loft in Garage 8 (pigeon fancier).
      * Interacting triggers PigeonRacingSystem UI. 8 hits to break; yields WOOD.
      */
-    PIGEON_COOP_PROP(1.80f, 1.60f, 0.90f, 8, Material.WOOD);
+    PIGEON_COOP_PROP(1.80f, 1.60f, 0.90f, 8, Material.WOOD),
+
+    // ── Issue #1151: Northfield Sporting & Social Club ────────────────────────
+
+    /**
+     * CHALK_SCOREBOARD_PROP — a wall-mounted chalk scoreboard beside the dartboard.
+     * Displays current 501 scores for the active darts game.
+     * Press E to view; non-interactive during matches. 3 hits to break; yields WOOD.
+     */
+    CHALK_SCOREBOARD_PROP(0.80f, 1.20f, 0.05f, 3, Material.WOOD),
+
+    /**
+     * BAR_PUMP_PROP — a row of hand-pull beer pumps behind the members' bar.
+     * Press E to order a drink (BITTER, MILD, or LAGER_TOP) if holding COIN.
+     * Members get half-price; non-members cannot order.
+     * 6 hits to break; yields SCRAP_METAL.
+     */
+    BAR_PUMP_PROP(0.60f, 1.20f, 0.30f, 6, Material.SCRAP_METAL),
+
+    /**
+     * CIGARETTE_MACHINE_PROP — a wall-mounted cigarette vending machine near the entrance.
+     * Press E to buy a pack for 3 COIN. Not tied to any system mechanic; flavour prop.
+     * 4 hits to break; yields SCRAP_METAL.
+     */
+    CIGARETTE_MACHINE_PROP(0.50f, 1.40f, 0.30f, 4, Material.SCRAP_METAL),
+
+    /**
+     * CLUB_SIGN_PROP — the external sign above the front door:
+     * "Northfield Sporting &amp; Social Club — Members Only".
+     * Press E for flavour text. 2 hits to break; yields WOOD.
+     */
+    CLUB_SIGN_PROP(1.50f, 0.50f, 0.10f, 2, Material.WOOD),
+
+    /**
+     * PROTECTION_ENVELOPE_PROP — a brown envelope on the back-room table containing 20 COIN.
+     * Appears Mon 19:55; collected by MARCHETTI_ENFORCER at 20:00.
+     * Stealing it (E during 19:55–20:00) triggers Tommy ambush + Wanted +3.
+     * 1 hit to break; yields COIN (20).
+     */
+    PROTECTION_ENVELOPE_PROP(0.20f, 0.05f, 0.12f, 1, Material.COIN);
 
     // ─────────────────────────────────────────────────────────────────────────
     // Issue #719: Collision and destructibility data


### PR DESCRIPTION
## Summary
Automated fix for issue #1151.

## Changes
- Fix #1151: automated fix

Closes #1151