### PR TITLE
Fix #1153: Add Northfield Community Centre — Aerobics, Support Groups, the Noticeboard Economy & the Council Grant Scam

### DIFF
--- a/src/main/java/ragamuffin/building/Material.java
+++ b/src/main/java/ragamuffin/building/Material.java
@@ -3680,7 +3680,89 @@ public enum Material {
      * Using it during the quiz guarantees correct answers but has 30% chance of detection.
      * Tooltip: "Capital of Peru? Lima. Everyone always forgets Lima."
      */
-    QUIZ_ANSWER_SHEET("Quiz Answer Sheet");
+    QUIZ_ANSWER_SHEET("Quiz Answer Sheet"),
+
+    // ── Issue #1153: Northfield Community Centre ──────────────────────────────
+
+    /**
+     * Aerobics Pass — issued by Denise (COMMUNITY_CENTRE_MANAGER) for 1 COIN.
+     * Grants entry to Sandra's aerobics sessions. Expires after one session.
+     * Tooltip: "Sandra says bring a towel. She's not joking."
+     */
+    AEROBICS_PASS("Aerobics Pass"),
+
+    /**
+     * CAB Referral Letter — issued by Derek (CAB_VOLUNTEER) at the Tuesday drop-in.
+     * Halves the FoodBank waiting time when presented at the food bank counter.
+     * Tooltip: "Derek's signed it. That actually means something."
+     */
+    CAB_REFERRAL_LETTER("CAB Referral Letter"),
+
+    /**
+     * Character Reference Letter — issued by Derek (CAB_VOLUNTEER) at the Tuesday drop-in.
+     * Reduces MagistratesCourtSystem sentence by one tier when presented in court.
+     * Tooltip: "Northfield Community Centre confirms that you have been known to attend things."
+     */
+    CHARACTER_REFERENCE_LETTER("Character Reference Letter"),
+
+    /**
+     * Grant Application Form — stolen from the FILING_CABINET_PROP in the back corridor.
+     * Used at the PHOTOCOPIER_PROP to create a FORGED_GRANT_APPLICATION.
+     * Can also be legitimately submitted with Denise's help (trust ≥ 30).
+     * Tooltip: "Section 4b is surprisingly philosophical."
+     */
+    GRANT_APPLICATION_FORM("Grant Application Form"),
+
+    /**
+     * Forged Grant Application — a doctored copy of the GRANT_APPLICATION_FORM.
+     * Posted at POST_BOX_PROP. After 3 in-game days, yields GRANT_CHEQUE (30 COIN).
+     * 25% catch rate (×2 at Notoriety Tier 3+); if caught: OBTAINING_MONEY_BY_DECEPTION charge.
+     * Tooltip: "Community Pool Table — Equipment &amp; Installation. You've definitely planned this."
+     */
+    FORGED_GRANT_APPLICATION("Forged Grant Application"),
+
+    /**
+     * Grant Cheque — a council cheque for 30 COIN, received after a successful grant.
+     * Cashed at the Post Office or bank. Awards GRANT_GRABBER on legitimate use, or
+     * triggers prosecution if the forgery is discovered first.
+     * Tooltip: "Pay to the bearer: thirty pounds. For a pool table. Community benefit."
+     */
+    GRANT_CHEQUE("Grant Cheque"),
+
+    /**
+     * Counterfeit Flyer — a fake community event flyer used to mislead NPCs.
+     * Can be pinned to NOTICE_BOARD_PROP to redirect NPCs away from a heist area.
+     * Tooltip: "Free bingo night. Definitely real. Don't tell anyone."
+     */
+    COUNTERFEIT_FLYER("Counterfeit Flyer"),
+
+    /**
+     * Curry and Rice — a portion of community curry served at Saturday night curry night.
+     * Costs 2 COIN from CURRY_COOK NPC. Restores +12 Warmth and +15 Hunger.
+     * Tooltip: "Best meal in Northfield. Don't argue."
+     */
+    CURRY_AND_RICE("Curry and Rice"),
+
+    /**
+     * Naan — a side of naan bread from the Saturday curry night.
+     * Restores +5 Hunger. Free with TINNED_GOODS donation.
+     * Tooltip: "Freshly made. You can tell."
+     */
+    NAAN("Naan"),
+
+    /**
+     * Samosa — two vegetable samosas from the community curry night starters.
+     * Restores +4 Hunger, +2 Warmth.
+     * Tooltip: "Go on. They're only small."
+     */
+    SAMOSA("Samosa"),
+
+    /**
+     * Mango Lassi — a cold yoghurt drink from the curry night.
+     * Restores +3 Hunger, +2 Warmth.
+     * Tooltip: "More of a palate cleanser than a drink. Still nice though."
+     */
+    MANGO_LASSI("Mango Lassi");
 
     private final String displayName;
 
@@ -4611,6 +4693,29 @@ public enum Material {
                                                     0.25f, 0.25f, 0.28f); // Dark metal
             case QUIZ_ANSWER_SHEET:       return cs(0.95f, 0.95f, 0.88f,  // Off-white paper
                                                     0.20f, 0.20f, 0.60f); // Blue ink lines
+
+            // Issue #1153: Northfield Community Centre
+            case AEROBICS_PASS:           return cs(0.88f, 0.22f, 0.55f,  // Hot pink pass
+                                                    0.98f, 0.90f, 0.95f); // Light background
+            case CAB_REFERRAL_LETTER:     return cs(0.92f, 0.92f, 0.88f,  // White paper
+                                                    0.10f, 0.30f, 0.68f); // CAB blue stamp
+            case CHARACTER_REFERENCE_LETTER: return cs(0.92f, 0.92f, 0.88f, // White paper
+                                                    0.22f, 0.50f, 0.22f); // Green approving stamp
+            case GRANT_APPLICATION_FORM:  return cs(0.90f, 0.88f, 0.78f,  // Cream council paper
+                                                    0.10f, 0.28f, 0.65f); // Blue council header
+            case FORGED_GRANT_APPLICATION: return cs(0.88f, 0.82f, 0.68f, // Slightly off cream
+                                                    0.38f, 0.22f, 0.65f); // Suspicious purple hue
+            case GRANT_CHEQUE:            return cs(0.92f, 0.92f, 0.82f,  // Cheque cream
+                                                    0.10f, 0.48f, 0.22f); // Green bank stamp
+            case COUNTERFEIT_FLYER:       return cs(0.98f, 0.95f, 0.75f,  // Yellow flyer
+                                                    0.88f, 0.20f, 0.20f); // Red headline text
+            case CURRY_AND_RICE:          return cs(0.82f, 0.55f, 0.12f,  // Golden curry sauce
+                                                    0.92f, 0.88f, 0.72f); // White rice
+            case NAAN:                    return c(0.88f, 0.78f, 0.55f);  // Warm bread tan
+            case SAMOSA:                  return cs(0.78f, 0.62f, 0.30f,  // Pastry gold
+                                                    0.55f, 0.72f, 0.22f); // Pea green filling hint
+            case MANGO_LASSI:             return cs(0.98f, 0.78f, 0.25f,  // Mango orange-yellow
+                                                    0.98f, 0.95f, 0.88f); // Creamy white
 
             default:             return c(0.5f, 0.5f, 0.5f);
         }
@@ -6037,6 +6142,30 @@ public enum Material {
                 return IconShape.TOOL;        // steel-tip darts
             case QUIZ_ANSWER_SHEET:
                 return IconShape.FLAT_PAPER;  // answer sheet
+
+            // Issue #1153: Northfield Community Centre
+            case AEROBICS_PASS:
+                return IconShape.CARD;        // laminated day pass
+            case CAB_REFERRAL_LETTER:
+                return IconShape.FLAT_PAPER;  // official referral letter
+            case CHARACTER_REFERENCE_LETTER:
+                return IconShape.FLAT_PAPER;  // character reference form
+            case GRANT_APPLICATION_FORM:
+                return IconShape.FLAT_PAPER;  // council grant form
+            case FORGED_GRANT_APPLICATION:
+                return IconShape.FLAT_PAPER;  // forged form
+            case GRANT_CHEQUE:
+                return IconShape.FLAT_PAPER;  // council cheque
+            case COUNTERFEIT_FLYER:
+                return IconShape.FLAT_PAPER;  // A5 flyer
+            case CURRY_AND_RICE:
+                return IconShape.FOOD;        // curry portion in tray
+            case NAAN:
+                return IconShape.FOOD;        // flatbread
+            case SAMOSA:
+                return IconShape.FOOD;        // triangular pastry
+            case MANGO_LASSI:
+                return IconShape.BOTTLE;      // yoghurt drink cup
 
             default:
                 return IconShape.BOX;

--- a/src/main/java/ragamuffin/core/RumourType.java
+++ b/src/main/java/ragamuffin/core/RumourType.java
@@ -406,5 +406,32 @@ public enum RumourType {
      * — seeded by LockUpGarageSystem when the hoarder clearance quest is activated (Garage 2).
      * Spreads via PENSIONER and PUBLIC NPCs.
      * Directs player to Garage 2 for the BRIC_A_BRAC_BANDIT quest chain. */
-    HOARDER_CLEARANCE;
+    HOARDER_CLEARANCE,
+
+    // ── Issue #1153: Northfield Community Centre ──────────────────────────────
+
+    /** "Someone at the community centre had their photocopier going mad — heard it from the road."
+     * — seeded by CommunityCentreSystem when the player uses the PHOTOCOPIER_PROP to forge a grant
+     *   application (HIGH noise, 15-block radius).
+     * Spreads via PUBLIC and PENSIONER NPCs within 15 blocks of the community centre.
+     * Minor Notoriety spike (+2) if any NPC within radius. */
+    COMMUNITY_CENTRE_PHOTOCOPIER,
+
+    /** "Heard someone's been fiddling the council grant forms at the community centre."
+     * — seeded by CommunityCentreSystem when a FORGED_GRANT_APPLICATION is posted
+     *   and the 25% catch rate fires (×2 at Notoriety Tier 3+).
+     * Spreads via PUBLIC NPCs; triggers MagistratesCourtSystem OBTAINING_MONEY_BY_DECEPTION charge. */
+    GRANT_FRAUD,
+
+    /** "Brenda said someone came to the NA meeting who's been in all sorts of bother."
+     * — seeded by CommunityCentreSystem from Brenda (NA_CHAIR) after a player share-story
+     *   event when Notoriety ≥ 30. 15% chance to fire.
+     * Spreads via NA_ATTENDEE NPCs. */
+    NA_RECOGNITION,
+
+    /** "Curry night at the community centre Saturday — best food in Northfield for two coin."
+     * — seeded weekly by CommunityCentreSystem at 17:00 on Saturdays before curry night.
+     * Spreads via COMMUNITY_MEMBER and PUBLIC NPCs.
+     * Draws nearby NPCs toward the COMMUNITY_CENTRE landmark. */
+    CURRY_NIGHT;
 }

--- a/src/main/java/ragamuffin/core/StreetSkillSystem.java
+++ b/src/main/java/ragamuffin/core/StreetSkillSystem.java
@@ -112,7 +112,12 @@ public class StreetSkillSystem {
         /** Issue #1020: Darts — played at the social club DARTBOARD_PROP or pub dartboard.
          *  Raw integer points (0–10). Improves accuracy in 301 mini-game:
          *  level 0–2: baseline; 3–5: +1 scoring accuracy tier; 6+: double-out bonus. */
-        DARTS
+        DARTS,
+
+        /** Issue #1153: Aerobics — trained at Sandra's Mon/Wed/Fri class at the Community Centre.
+         *  Raw integer points (0–10). Improves rhythm prompt timing window:
+         *  level 0–2: baseline 0.4s window; 3–5: 0.55s window; 6+: 0.70s window. */
+        AEROBICS
     }
 
     // ── Tier enum ─────────────────────────────────────────────────────────────

--- a/src/main/java/ragamuffin/entity/NPCType.java
+++ b/src/main/java/ragamuffin/entity/NPCType.java
@@ -1728,7 +1728,94 @@ public enum NPCType {
      * Speech: "Tommy sends his regards." / "Is it ready?" /
      *         "Don't make this difficult." / "You've made a very big mistake."
      */
-    MARCHETTI_ENFORCER(60f, 14f, 1.8f, false);
+    MARCHETTI_ENFORCER(60f, 14f, 1.8f, false),
+
+    // ── Issue #1153: Northfield Community Centre ──────────────────────────────
+
+    /**
+     * Community Centre Manager — Denise, the centre manager.
+     * Patrols the front desk 09:00–17:00 Mon–Fri. Passive; can issue AEROBICS_PASS
+     * and help with legitimate grant applications (trust ≥ 30).
+     * Speech: "Morning! What can I help you with?" /
+     *         "Sessions are on the board by the entrance." /
+     *         "We're a community resource — treat it like one."
+     */
+    COMMUNITY_CENTRE_MANAGER(20f, 0f, 0f, false),
+
+    /**
+     * Community Centre Volunteer — a general volunteer helper.
+     * Sets up chairs, makes tea, runs the tuck shop. Passive.
+     */
+    COMMUNITY_CENTRE_VOLUNTEER(20f, 0f, 0f, false),
+
+    /**
+     * Aerobics Instructor — Sandra, who runs Mon/Wed/Fri 09:30–10:30 aerobics.
+     * Leads the rhythm mini-game with 8 prompts. Passive; speech encourages exercise.
+     */
+    AEROBICS_INSTRUCTOR(20f, 0f, 0f, false),
+
+    /**
+     * Aerobics Participant — regular attendee of Sandra's aerobics class.
+     * 4–8 spawn during session hours. Passive.
+     */
+    AEROBICS_PARTICIPANT(20f, 0f, 0f, false),
+
+    /**
+     * Young Mum — attends the Toddler Playgroup Tue/Thu mornings.
+     * Brings a TODDLER NPC. Passive; gossips.
+     */
+    YOUNG_MUM(20f, 0f, 0f, false),
+
+    /**
+     * Toddler — a small child attending the Tuesday/Thursday playgroup.
+     * Passive; follows nearest YOUNG_MUM. Runs around near BOUNCY_CASTLE_PROP.
+     */
+    TODDLER(5f, 0f, 0f, false),
+
+    /**
+     * Citizens Advice Volunteer — Derek, who runs the Tue 14:00–16:00 CAB drop-in.
+     * Gives CAB_REFERRAL_LETTER (halves FoodBank wait) or CHARACTER_REFERENCE_LETTER
+     * (reduces MagistratesCourtSystem sentence by one tier). Passive.
+     * Speech: "Take a seat — we'll get to you." /
+     *         "I can't give legal advice, but I can point you in the right direction."
+     */
+    CAB_VOLUNTEER(20f, 0f, 0f, false),
+
+    /**
+     * NA Attendee — regular at the Thursday 19:00–20:30 Narcotics Anonymous meeting.
+     * Passive; listens during share-story mechanic.
+     */
+    NA_ATTENDEE(20f, 0f, 0f, false),
+
+    /**
+     * NA Chair — Brenda, who facilitates the Thursday NA meeting.
+     * Passive; awards COMMUNITY_TRUST after sharing. Seeds a rumour at trust ≥ 30.
+     */
+    NA_CHAIR(20f, 0f, 0f, false),
+
+    /**
+     * Community Member — a generic Northfield resident who attends community events
+     * (curry night, aerobics, etc.). Passive.
+     */
+    COMMUNITY_MEMBER(20f, 0f, 0f, false),
+
+    /**
+     * Karate Kid — a child attending the Wednesday 18:30 Karate Juniors session.
+     * Passive; follows KARATE_INSTRUCTOR.
+     */
+    KARATE_KID(15f, 2f, 3.0f, false),
+
+    /**
+     * Karate Instructor — runs the Wednesday 18:30 Karate Juniors class.
+     * Passive; demonstrates moves. Hostile if provoked (attacks defending).
+     */
+    KARATE_INSTRUCTOR(30f, 8f, 1.5f, false),
+
+    /**
+     * Curry Cook — volunteers at the Saturday 18:00–21:00 curry night.
+     * Sells CURRY_AND_RICE for 2 COIN (+12 Warmth, +15 Hunger). Passive.
+     */
+    CURRY_COOK(20f, 0f, 0f, false);
 
     private final float maxHealth;
     private final float attackDamage;   // Damage per hit to player

--- a/src/main/java/ragamuffin/ui/AchievementType.java
+++ b/src/main/java/ragamuffin/ui/AchievementType.java
@@ -3182,6 +3182,72 @@ public enum AchievementType {
         "Grassed Up",
         "Tipped off the police about Tommy's collection. 40% chance they find out it was you. Good luck.",
         1
+    ),
+
+    // ── Issue #1153: Northfield Community Centre ──────────────────────────────
+
+    /**
+     * Awarded when the player reaches 100 NORTHFIELD_RESIDENTS faction sub-rep.
+     * Also grants NeighbourhoodSystem vibes +20 permanently.
+     */
+    COMMUNITY_PILLAR(
+        "Community Pillar",
+        "They actually like you here. You're on the noticeboard. With a photo. A good photo.",
+        1
+    ),
+
+    /**
+     * Awarded when the player completes an aerobics session scoring 6+ out of 8 prompts.
+     */
+    STEP_TOGETHER(
+        "Step Together",
+        "You kept up with Sandra. Well, mostly. She was too polite to say anything.",
+        1
+    ),
+
+    /**
+     * Awarded when the player successfully posts a FORGED_GRANT_APPLICATION and collects the GRANT_CHEQUE.
+     */
+    GRANT_GRABBER(
+        "Grant Grabber",
+        "Thirty coin from the council. For a community pool table. That doesn't exist. Yet.",
+        1
+    ),
+
+    /**
+     * Awarded when the player steals the BISCUIT_TIN_PROP contents during a session.
+     */
+    BISCUIT_BANDIT(
+        "Biscuit Bandit",
+        "You nicked the Rich Tea. During a bereavement support group. Shameless.",
+        1
+    ),
+
+    /**
+     * Awarded when the player completes the legitimate grant application with Denise's help.
+     */
+    HONEST_CITIZEN(
+        "Honest Citizen",
+        "You did it properly. Filled in the forms. Waited three weeks. Denise is genuinely chuffed.",
+        1
+    ),
+
+    /**
+     * Awarded when the player shares their story at the Thursday NA meeting (first time).
+     */
+    ANONYMOUS(
+        "Anonymous",
+        "You shared. They listened. Nobody said a word afterwards. That's how it's supposed to work.",
+        1
+    ),
+
+    /**
+     * Awarded when the player attends 8 aerobics sessions (completing the full 8-week block).
+     */
+    CLEAN_EIGHT(
+        "Clean Eight",
+        "Eight sessions without missing one. Sandra saved you a spot at the front.",
+        8
     );
 
     private final String name;

--- a/src/main/java/ragamuffin/world/PropType.java
+++ b/src/main/java/ragamuffin/world/PropType.java
@@ -2185,7 +2185,67 @@ public enum PropType {
      * Stealing it (E during 19:55–20:00) triggers Tommy ambush + Wanted +3.
      * 1 hit to break; yields COIN (20).
      */
-    PROTECTION_ENVELOPE_PROP(0.20f, 0.05f, 0.12f, 1, Material.COIN);
+    PROTECTION_ENVELOPE_PROP(0.20f, 0.05f, 0.12f, 1, Material.COIN),
+
+    // ── Issue #1153: Northfield Community Centre ──────────────────────────────
+
+    /**
+     * MAT_PROP — a rolled foam exercise mat stacked at the hall wall.
+     * Present during aerobics sessions. 2 hits to break; yields nothing.
+     */
+    MAT_PROP(0.60f, 0.15f, 0.18f, 2, null),
+
+    /**
+     * STACKING_CHAIR_PROP — a blue plastic stacking chair used for support-group circles.
+     * 2 hits to break; yields WOOD.
+     */
+    STACKING_CHAIR_PROP(0.45f, 0.90f, 0.45f, 2, Material.WOOD),
+
+    /**
+     * TEA_URN_PROP — a large stainless-steel tea urn on the kitchen counter.
+     * Press E to get a free hot drink (+2 Warmth). 4 hits to break; yields SCRAP_METAL.
+     */
+    TEA_URN_PROP(0.35f, 0.55f, 0.35f, 4, Material.SCRAP_METAL),
+
+    /**
+     * BISCUIT_TIN_PROP — a decorative tin of assorted biscuits on the refreshments table.
+     * Press E to steal contents (awards BISCUIT_BANDIT if in a support-group session).
+     * 1 hit to break; yields nothing.
+     */
+    BISCUIT_TIN_PROP(0.22f, 0.16f, 0.22f, 1, null),
+
+    /**
+     * BOUNCY_CASTLE_PROP — an inflatable bouncy castle for the Toddler Playgroup (Tue/Thu).
+     * Decorative; deflates at session end. 5 hits to break; yields nothing.
+     */
+    BOUNCY_CASTLE_PROP(2.40f, 1.80f, 2.40f, 5, null),
+
+    /**
+     * PHOTOCOPIER_PROP — an office photocopier in the community centre back corridor.
+     * Press E with GRANT_APPLICATION_FORM to create FORGED_GRANT_APPLICATION.
+     * Generates HIGH noise (level 3.5, 15-block radius via NoiseSystem).
+     * 6 hits to break; yields SCRAP_METAL.
+     */
+    PHOTOCOPIER_PROP(0.70f, 1.10f, 0.60f, 6, Material.SCRAP_METAL),
+
+    /**
+     * SERVING_TABLE_PROP — a folding trestle table used for curry night food service.
+     * 3 hits to break; yields WOOD.
+     */
+    SERVING_TABLE_PROP(1.80f, 0.85f, 0.70f, 3, Material.WOOD),
+
+    /**
+     * POOL_TABLE_PROP — a full-size pool table unlocked by the legitimate grant application.
+     * Interacting (E) with COIN starts a game. 8 hits to break; yields WOOD.
+     */
+    POOL_TABLE_PROP(2.20f, 0.85f, 1.20f, 8, Material.WOOD),
+
+    /**
+     * FILING_CABINET_PROP — a grey metal filing cabinet in the community centre back corridor.
+     * Press E with LOCKPICK to open (70% success) and steal GRANT_APPLICATION_FORM.
+     * 5 hits to break; yields SCRAP_METAL.
+     */
+    FILING_CABINET_PROP(0.55f, 1.30f, 0.50f, 5, Material.SCRAP_METAL);
 
     // ─────────────────────────────────────────────────────────────────────────
     // Issue #719: Collision and destructibility data


### PR DESCRIPTION
## Summary
Automated fix for issue #1153.

## Changes
- Fix #1153: automated fix

Closes #1153