### PR TITLE
Fix #1171: Add Northfield TV Licence — Threatening Letters, the Detector Van & the Evasion Economy

### DIFF
--- a/src/main/java/ragamuffin/building/Material.java
+++ b/src/main/java/ragamuffin/building/Material.java
@@ -3973,7 +3973,30 @@ public enum Material {
 
     /** ABA Trophy 1987 — the stolen trophy from Tommy's display cabinet.
      * Quest item: retrieve from Derek's house → return to Tommy → LEGACY_OF_THE_RING. */
-    ABA_TROPHY("ABA Trophy 1987");
+    ABA_TROPHY("ABA Trophy 1987"),
+
+    // ── Issue #1171: Northfield TV Licence ────────────────────────────────────
+
+    /**
+     * TV Licence Letter — buff envelope from the BBC Licensing Authority.
+     * Issued every 7 in-game days to unlicensed properties. Status escalates
+     * UNLICENSED → WARNED → FINAL_NOTICE → SUMMONED.
+     */
+    TV_LICENCE_LETTER("TV Licence Letter"),
+
+    /**
+     * TV Licence Certificate — proof of payment (12 COIN at LETTERBOX_PROP).
+     * Frameable on wall; grants +2 Community Respect. Valid for 28 in-game days.
+     */
+    TV_LICENCE_CERTIFICATE("TV Licence Certificate"),
+
+    /**
+     * Forged TV Licence — craftable at StreetRep ≥ 40 using BLANK_PAPER + PRINTER_INK
+     * via PRINTER_PROP. Sellable to PUBLIC/PENSIONER NPCs for 8 COIN each.
+     * 20% chance each sale reports it, seeding FORGED_DOCUMENT criminal record
+     * and wanted level. Three sales triggers a NewspaperSystem headline.
+     */
+    FORGED_TV_LICENCE("Forged TV Licence");
 
     private final String displayName;
 
@@ -4992,6 +5015,14 @@ public enum Material {
             case SPEED_BAG_CHALK:       return c(0.90f, 0.90f, 0.88f);  // White chalk dust
             case ABA_TROPHY:            return cs(0.82f, 0.68f, 0.15f,  // Gold trophy body
                                                   0.62f, 0.48f, 0.10f); // Dark gold base
+
+            // Issue #1171: Northfield TV Licence
+            case TV_LICENCE_LETTER:     return cs(0.88f, 0.88f, 0.75f,  // Cream envelope
+                                                  0.72f, 0.20f, 0.10f); // Red BBC stripe
+            case TV_LICENCE_CERTIFICATE: return cs(0.92f, 0.88f, 0.75f, // Official cream paper
+                                                   0.20f, 0.50f, 0.80f); // Blue official seal
+            case FORGED_TV_LICENCE:     return cs(0.82f, 0.78f, 0.65f,  // Fake cream paper
+                                                  0.55f, 0.15f, 0.10f); // Suspicious red marks
 
             default:             return c(0.5f, 0.5f, 0.5f);
         }
@@ -6556,6 +6587,14 @@ public enum Material {
                 return IconShape.BOX;         // chalk block
             case ABA_TROPHY:
                 return IconShape.CYLINDER;    // trophy cup shape
+
+            // Issue #1171: Northfield TV Licence
+            case TV_LICENCE_LETTER:
+                return IconShape.FLAT_PAPER;  // buff envelope
+            case TV_LICENCE_CERTIFICATE:
+                return IconShape.FLAT_PAPER;  // official certificate
+            case FORGED_TV_LICENCE:
+                return IconShape.FLAT_PAPER;  // forged certificate
 
             default:
                 return IconShape.BOX;

--- a/src/main/java/ragamuffin/core/CriminalRecord.java
+++ b/src/main/java/ragamuffin/core/CriminalRecord.java
@@ -484,7 +484,22 @@ public class CriminalRecord {
          * and the 40% catch chance fires during pat-down.
          * Penalty: Notoriety +3, ejection from current event, BOXING_CLUB banned 3 days.
          */
-        FIGHT_FIXING("Fight fixing (loaded glove — illegal equipment)");
+        FIGHT_FIXING("Fight fixing (loaded glove — illegal equipment)"),
+
+        /**
+         * Issue #1171: Recorded when the player is caught EVADING TV Licence obligations
+         * with a lit TV_PROP in range and the DETECTOR_VAN 25% detection chance fires.
+         * Also recorded on SUMMONED status auto-referral to MagistratesCourtSystem.
+         * Penalty: Notoriety +5, WantedSystem Tier 1.
+         */
+        TV_LICENCE_EVASION("TV licence evasion"),
+
+        /**
+         * Issue #1171: Recorded when an NPC reports a FORGED_TV_LICENCE sale to police.
+         * Seeds wanted level and links to FORGED_DOCUMENT in court proceedings.
+         * Penalty: Notoriety +8, WantedSystem Tier 2.
+         */
+        FORGED_DOCUMENT("Forged document (TV licence)");
 
         private final String displayName;
 

--- a/src/main/java/ragamuffin/entity/NPCType.java
+++ b/src/main/java/ragamuffin/entity/NPCType.java
@@ -1896,7 +1896,18 @@ public enum NPCType {
      * White-collar boxer — office worker opponent in the underground circuit.
      * Spawns on alternate Saturdays 22:00. Better funded, worse technique.
      */
-    WHITE_COLLAR_BOXER(30f, 5f, 2.0f, false);
+    WHITE_COLLAR_BOXER(30f, 5f, 2.0f, false),
+
+    // ── Issue #1171: Northfield TV Licence ────────────────────────────────────
+
+    /**
+     * TV Licence Officer — BBC Licensing Authority enforcement officer.
+     * Crawls residential streets as part of the DETECTOR_VAN patrol every 14 in-game days.
+     * Can knock on the player's door to conduct an inspection. Can be bribed (4 COIN),
+     * intimidated by the dog (bond ≥ 50 + off-lead), or let in (fines 8 COIN).
+     * Not hostile; does not pursue the player.
+     */
+    LICENCE_OFFICER(40f, 0f, 0f, false);
 
     private final float maxHealth;
     private final float attackDamage;   // Damage per hit to player

--- a/src/main/java/ragamuffin/ui/AchievementType.java
+++ b/src/main/java/ragamuffin/ui/AchievementType.java
@@ -3520,6 +3520,53 @@ public enum AchievementType {
         "Gym Rat",
         "Three sessions before teatime. Tommy's seen it all now.",
         1
+    ),
+
+    // ── Issue #1171: Northfield TV Licence ────────────────────────────────────
+
+    /**
+     * Awarded for paying for a TV licence at the LETTERBOX_PROP.
+     */
+    HONEST_TELLY(
+        "Licence to Watch",
+        "You paid your TV licence. The BBC thanks you. Seriously.",
+        1
+    ),
+
+    /**
+     * Awarded for reaching SUMMONED status without ever paying.
+     */
+    EVADER(
+        "Dodger",
+        "The van's been round three times. You still haven't paid.",
+        1
+    ),
+
+    /**
+     * Awarded for selling a FORGED_TV_LICENCE to an NPC.
+     */
+    BOGUS_INSPECTOR(
+        "Bogus Inspector",
+        "You sold a fake licence. The check's in the post.",
+        1
+    ),
+
+    /**
+     * Awarded for evading detection when the DETECTOR_VAN passes with a lit TV.
+     */
+    DETECTOR_PROOF(
+        "Detector Proof",
+        "The van went past. The telly was on. They didn't notice.",
+        1
+    ),
+
+    /**
+     * Awarded for selling 3 FORGED_TV_LICENCE items (the NewspaperSystem headline trigger).
+     */
+    LOWEST_OF_THE_LOW_TELLY(
+        "TV Licence Scammer",
+        "Three pensioners. Three fake licences. The Daily Ragamuffin knows your face.",
+        3
     );
 
     private final String name;


### PR DESCRIPTION
## Summary
Automated fix for issue #1171.

## Changes
- Fix #1171: automated fix

Closes #1171