### PR TITLE
Fix #1192: Add Northfield Sporting & Social Club — Members Bar, Darts League, Back-Room Pontoon & AGM Scam

### DIFF
--- a/src/main/java/ragamuffin/core/RumourType.java
+++ b/src/main/java/ragamuffin/core/RumourType.java
@@ -468,5 +468,13 @@ public enum RumourType {
      * — seeded by BoxingClubSystem when the white-collar circuit unlocks (2nd win).
      * Spreads via FIGHT_PROMOTER and BOXING_PROSPECT NPCs within 20 blocks of BOXING_CLUB.
      * Draws WHITE_COLLAR_BOXER NPCs toward the gym on alternate Saturdays. */
-    UNDERGROUND_FIGHT;
+    UNDERGROUND_FIGHT,
+
+    // ── Issue #1192: Northfield Sporting & Social Club ────────────────────────
+
+    /** "Mick at the social club back room was dealing from the bottom of the deck."
+     * — seeded by SportingSocialClubSystem when player catches CARD_DEALER cheating.
+     * Spreads via SOCIAL_CLUB_STEWARD and CLUB_REGULAR NPCs.
+     * Reduces MARCHETTI_CREW Respect by 5 (they run Mick). */
+    CARD_CHEAT;
 }

--- a/src/main/java/ragamuffin/entity/NPCType.java
+++ b/src/main/java/ragamuffin/entity/NPCType.java
@@ -2001,7 +2001,14 @@ public enum NPCType {
      * of The Feathers pub. Passive; interacts via menu when player presses E.
      * Buys and sells criminal intelligence via InformationBrokerSystem.
      */
-    INFO_BROKER(25f, 0f, 0f, false);
+    INFO_BROKER(25f, 0f, 0f, false),
+
+    /**
+     * Issue #1192: Mick the card dealer — runs the back-room Pontoon table at the
+     * Northfield Sporting &amp; Social Club on Friday/Saturday nights. Enters cheat mode
+     * after player wins 3 consecutive hands (hidden ace probability 0.6).
+     */
+    CARD_DEALER(30f, 0f, 0f, false);
 
     private final float maxHealth;
     private final float attackDamage;   // Damage per hit to player

--- a/src/main/java/ragamuffin/ui/AchievementType.java
+++ b/src/main/java/ragamuffin/ui/AchievementType.java
@@ -3773,6 +3773,64 @@ public enum AchievementType {
         "Nothing to Declare",
         "Five fortnights. Zero declared earnings. Brenda hasn't knocked. Yet.",
         1
+    ),
+
+    // ── Issue #1192: Northfield Sporting & Social Club ─────────────────────────
+
+    /**
+     * Issue #1192: Awarded when the player successfully joins the Northfield
+     * Sporting &amp; Social Club by paying 5 COIN for a CLUB_MEMBERSHIP_CARD.
+     */
+    CLUB_MEMBER(
+        "Members Only",
+        "You're a card-carrying member of the Northfield Sporting & Social Club. Ron gave you a nod.",
+        1
+    ),
+
+    /**
+     * Issue #1192: Awarded when the player wins a side-bet darts match at the
+     * Thursday Darts League at the social club.
+     * (DARTS_HUSTLER_CLUB already present — this entry has been merged into it.)
+     */
+
+    /**
+     * Issue #1192: Awarded when the player wins 3+ consecutive hands in the
+     * back-room Pontoon session.
+     */
+    BACK_ROOM_BANKER(
+        "Back Room Banker",
+        "Three on the spin at Mick's table. He wasn't pleased. Nobody ever is.",
+        1
+    ),
+
+    /**
+     * Issue #1192: Awarded when the player catches Mick the card dealer cheating
+     * using STREETWISE &ge; Journeyman skill.
+     */
+    CAUGHT_THE_CHEAT(
+        "Caught the Cheat",
+        "Caught Mick slipping an ace from his sleeve. He looked you dead in the eye. Said nothing.",
+        1
+    ),
+
+    /**
+     * Issue #1192: Awarded when the player embezzles club funds as Treasurer
+     * at the AGM without being caught.
+     */
+    COOKING_THE_BOOKS(
+        "Cooking the Books",
+        "You've been embezzling from the social club's petty cash. In fairness, so was Derek.",
+        1
+    ),
+
+    /**
+     * Issue #1192: Awarded when the player successfully intercepts the Marchetti
+     * Crew protection collector, landing 5 hits to drive them off.
+     */
+    CLUB_PROTECTOR(
+        "Club Protector",
+        "You saw off the Marchetti collector. Ron shook your hand. It was awkward but sincere.",
+        1
     );
 
     private final String name;

--- a/src/main/java/ragamuffin/world/PropType.java
+++ b/src/main/java/ragamuffin/world/PropType.java
@@ -1519,6 +1519,30 @@ public enum PropType {
      */
     EVIDENCE_PROP(0.30f, 0.20f, 0.20f, 99, null),
 
+    // ── Issue #1192: Additional Sporting & Social Club props ──────────────────
+
+    /**
+     * DARTS_TROPHY_PROP — a scratched silver trophy on the bar shelf above the
+     * dartboard. Awarded to the Thursday Darts League winner. Press E to read
+     * engraved names. Destroyed by 3 punches; yields SCRAP_METAL.
+     */
+    DARTS_TROPHY_PROP(0.30f, 0.40f, 0.20f, 3, Material.SCRAP_METAL),
+
+    /**
+     * AGM_ACCOUNTS_PROP — a ring-bound booklet of club accounts placed on the
+     * committee table during the first-Sunday-of-month AGM. Press E to inspect
+     * as Treasurer; embezzlement options displayed if player holds CLUB_MEMBERSHIP_CARD
+     * and is standing for Treasurer. Destroyed by 2 punches; yields nothing (paper).
+     */
+    AGM_ACCOUNTS_PROP(0.25f, 0.30f, 0.15f, 2, null),
+
+    /**
+     * BARSTOOL_PROP — a worn vinyl-topped barstool at the Members' Bar. Named
+     * regulars (Arthur, Derek, Brenda) are seated here. Press E to start a
+     * conversation and receive seeded rumours. Destroyed by 3 punches; yields WOOD.
+     */
+    BARSTOOL_PROP(0.40f, 0.70f, 0.40f, 3, Material.WOOD),
+
     // ── Issue #1114: Meredith & Sons Funeral Parlour ──────────────────────────
 
     /**


### PR DESCRIPTION
## Summary
Automated fix for issue #1192.

## Changes
- Fix #1192: automated fix

Closes #1192