### PR TITLE
Fix #1198: Add Northfield Traffic Warden — Clive, Parking Tickets, Wheel Clamps & the Pay-and-Display Hustle

### DIFF
--- a/src/main/java/ragamuffin/building/Material.java
+++ b/src/main/java/ragamuffin/building/Material.java
@@ -4305,7 +4305,48 @@ public enum Material {
      * Post to SUGGESTION_BOX_PROP at Council Office to force Janet's next
      * inspection to target a specific venue. One tip-off per in-game week.
      */
-    ANONYMOUS_NOTE("Anonymous Note");
+    ANONYMOUS_NOTE("Anonymous Note"),
+
+    // ── Issue #1198: Northfield Traffic Warden ────────────────────────────────
+
+    /**
+     * Pay-and-Display Ticket — bought from PAY_AND_DISPLAY_MACHINE_PROP (1 COIN/hr, max 4 hrs).
+     * Player must press E on their parked car to place it on the dashboard.
+     * Valid ticket prevents Clive from issuing a PCN at COUNCIL_CAR_PARK.
+     */
+    PAY_AND_DISPLAY_TICKET("Pay-and-Display Ticket"),
+
+    /**
+     * Penalty Charge Notice — issued by Clive (TRAFFIC_WARDEN) on a parking violation.
+     * Fine: 3 COIN if paid within 2 in-game days; 6 COIN standard; 12 COIN if clamped.
+     * Can be appealed at APPEAL_DESK_PROP at the COUNCIL_OFFICE.
+     * Recorded as PARKING_OFFENCE in CriminalRecord.
+     */
+    PENALTY_CHARGE_NOTICE("Penalty Charge Notice"),
+
+    /**
+     * Forged Parking Ticket — crafted at PHOTOCOPIER_PROP (GRAFTING ≥ Apprentice):
+     * PAY_AND_DISPLAY_TICKET + BLANK_PAPER → FORGED_PARKING_TICKET.
+     * Place on another car: 60% chance Clive detects forgery (FRAUD + Notoriety +6 + PCN).
+     * Sell to COMMUTER or CAFF_REGULAR NPCs for 1 COIN each.
+     * 5 sales in one day awards TICKET_TOUT achievement.
+     */
+    FORGED_PARKING_TICKET("Forged Parking Ticket"),
+
+    /**
+     * Wheel Clamp — dropped when the clamp is removed from a clamped car.
+     * Fence at scrapyard for 2 COIN (stolen clamp).
+     * Applied by Clive on a second-circuit repeat violation.
+     */
+    WHEEL_CLAMP("Wheel Clamp"),
+
+    /**
+     * Clive's Terminal — dropped if Clive is knocked out.
+     * Sell at pawn shop for 5 COIN.
+     * One-use: interact (E) with a PCN-marked car while holding CLIVE_TERMINAL
+     * to void the PCN (80% success chance).
+     */
+    CLIVE_TERMINAL("Clive's Terminal");
 
     private final String displayName;
 
@@ -7058,6 +7099,18 @@ public enum Material {
                 return IconShape.FLAT_PAPER;  // official notice
             case ANONYMOUS_NOTE:
                 return IconShape.FLAT_PAPER;  // folded note
+
+            // Issue #1198: Northfield Traffic Warden
+            case PAY_AND_DISPLAY_TICKET:
+                return IconShape.FLAT_PAPER;  // small ticket slip
+            case PENALTY_CHARGE_NOTICE:
+                return IconShape.FLAT_PAPER;  // yellow PCN envelope
+            case FORGED_PARKING_TICKET:
+                return IconShape.FLAT_PAPER;  // forged ticket slip
+            case WHEEL_CLAMP:
+                return IconShape.BOX;         // heavy metal device
+            case CLIVE_TERMINAL:
+                return IconShape.BOX;         // hand-held enforcement terminal
 
             default:
                 return IconShape.BOX;

--- a/src/main/java/ragamuffin/entity/NPCType.java
+++ b/src/main/java/ragamuffin/entity/NPCType.java
@@ -2017,7 +2017,28 @@ public enum NPCType {
      * 09:30–15:30. Passive; if assaulted seeds COUNCIL_ENFORCEMENT rumour, adds
      * ASSAULT_ON_OFFICIAL crime, Wanted +3. HP 25f, no attack, not hostile.
      */
-    ENVIRONMENTAL_HEALTH_OFFICER(25f, 0f, 0f, false);
+    ENVIRONMENTAL_HEALTH_OFFICER(25f, 0f, 0f, false),
+
+    // ── Issue #1198: Northfield Traffic Warden ────────────────────────────────
+
+    /**
+     * Clive — the town's sole civil enforcement officer (Traffic Warden).
+     * Male, 50s, yellow hi-vis tabard, peaked cap, hand-held terminal.
+     * Patrols high street, car park, and side streets Mon–Sat 08:00–18:00.
+     * Fixed circuit: each full patrol takes 8 in-game minutes.
+     * Passive; if assaulted seeds COUNCIL_ENFORCEMENT rumour, adds
+     * ASSAULT_ON_OFFICIAL to CriminalRecord, Wanted +3, NeighbourhoodSystem −5 vibes.
+     */
+    TRAFFIC_WARDEN(30f, 0f, 0f, false),
+
+    /**
+     * Brenda — Council Receptionist at the COUNCIL_OFFICE landmark.
+     * Staffs the front desk Mon–Fri 09:00–17:00. Passive; handles PCN appeals
+     * submitted at the APPEAL_DESK_PROP.
+     * Speech: "Take a number." / "You'll need to fill in the form."
+     *         / "Two working days and we'll write to you." / "Next, please."
+     */
+    COUNCIL_RECEPTIONIST(20f, 0f, 0f, false);
 
     private final float maxHealth;
     private final float attackDamage;   // Damage per hit to player

--- a/src/main/java/ragamuffin/world/LandmarkType.java
+++ b/src/main/java/ragamuffin/world/LandmarkType.java
@@ -600,7 +600,29 @@ public enum LandmarkType {
      * BEAD_CURTAIN_PROP. Players can buy and sell criminal intelligence here.
      * Managed by InformationBrokerSystem.
      */
-    INFO_BROKER_PUB;
+    INFO_BROKER_PUB,
+
+    // ── Issue #1198: Northfield Traffic Warden ────────────────────────────────
+
+    /**
+     * Issue #1198: COUNCIL_OFFICE — a bland 1970s civic building two blocks from
+     * the Magistrates' Court. Open Mon–Fri 09:00–17:00. Staffed by
+     * COUNCIL_RECEPTIONIST Brenda at the front desk.
+     * <p>Contains APPEAL_DESK_PROP where the player can submit PCN appeals.
+     * Submit with PENALTY_CHARGE_NOTICE + BLANK_PAPER; 2 in-game day wait.
+     * Base appeal success: 30%; +20% if machine broken; +15% if no prior offences.
+     * Managed by TrafficWardenSystem.
+     */
+    COUNCIL_OFFICE,
+
+    /**
+     * Issue #1198: VEHICLE_IMPOUND — the council impound lot on the industrial estate.
+     * Impounded cars are held here after a third circuit violation (towed by BAILIFF).
+     * Open Mon–Fri 09:00–17:00. Pay 20 COIN to retrieve vehicle.
+     * Vehicle removal uses TaxiSystem vehicle-movement logic for towing animation.
+     * Managed by TrafficWardenSystem.
+     */
+    VEHICLE_IMPOUND;
 
     /**
      * Returns the display name shown on the building's sign.
@@ -693,6 +715,8 @@ public enum LandmarkType {
             case RECYCLING_CENTRE:      return "Northfield Tip";
             case PROBATION_OFFICE:      return "Northfield Probation Service";
             case INFO_BROKER_PUB:       return "The Feathers";
+            case COUNCIL_OFFICE:        return "Northfield Council Office";
+            case VEHICLE_IMPOUND:       return "Vehicle Impound";
             default:                    return null; // No sign for parks, houses, etc.
         }
     }

--- a/src/main/java/ragamuffin/world/PropType.java
+++ b/src/main/java/ragamuffin/world/PropType.java
@@ -2539,7 +2539,45 @@ public enum PropType {
      * E-hold (5 s, GRAFTING ≥ Apprentice) raises venue condition +10.
      * Crowbar sabotage variant: condition −25, CRIMINAL_DAMAGE CrimeType.
      */
-    KITCHEN_PROP(1.20f, 1.00f, 0.80f, 10, null);
+    KITCHEN_PROP(1.20f, 1.00f, 0.80f, 10, null),
+
+    // ── Issue #1198: Northfield Traffic Warden ────────────────────────────────
+
+    /**
+     * Double-yellow line road marking — painted on the road surface along the high street.
+     * Any car parked here while Clive is on patrol will immediately receive a PCN
+     * (zero grace period). Destroyed by CROWBAR (CRIMINAL_DAMAGE CrimeType); +8 Notoriety.
+     */
+    DOUBLE_YELLOW_PROP(0.50f, 0.05f, 2.00f, 10, null),
+
+    /**
+     * Single-yellow line road marking — 2-hour max parking restriction (SIDE_STREET_ZONE).
+     * Car parked here for &gt; 120 in-game minutes will receive a PCN from Clive.
+     */
+    SINGLE_YELLOW_PROP(0.50f, 0.05f, 2.00f, 8, null),
+
+    /**
+     * Pay-and-Display ticket machine — standalone yellow metal column at COUNCIL_CAR_PARK.
+     * Press E to buy a PAY_AND_DISPLAY_TICKET (1 COIN per hour, max 4 hours).
+     * Vandalism with CROWBAR: disables machine for 1 in-game day, seeds VANDALISM rumour,
+     * +8 Notoriety, +20 NoiseSystem level. Sets broken-machine flag (+20% appeal success).
+     * Yields SCRAP_METAL when destroyed.
+     */
+    PAY_AND_DISPLAY_MACHINE_PROP(0.40f, 1.60f, 0.40f, 12, Material.SCRAP_METAL),
+
+    /**
+     * Wheel clamp — a bright yellow Denver boot applied to a car's wheel by Clive
+     * after a second-circuit violation. Car.isClamped() == true while present.
+     * Removed when the fine (12 COIN) is paid; drops WHEEL_CLAMP material.
+     */
+    WHEEL_CLAMP_PROP(0.60f, 0.40f, 0.40f, 15, Material.WHEEL_CLAMP),
+
+    /**
+     * Appeal desk — counter prop at the COUNCIL_OFFICE where the player submits
+     * a PCN appeal. Press E (must hold PENALTY_CHARGE_NOTICE + BLANK_PAPER).
+     * Staffed by COUNCIL_RECEPTIONIST Brenda. Appeal takes 2 in-game days.
+     */
+    APPEAL_DESK_PROP(1.20f, 0.90f, 0.70f, 8, Material.SCRAP_METAL);
 
     // ─────────────────────────────────────────────────────────────────────────
     // Issue #719: Collision and destructibility data


### PR DESCRIPTION
## Summary
Automated fix for issue #1198.

## Changes
- Fix #1198: automated fix

Closes #1198