### PR TITLE
Fix #1205: Add Northfield DVSA Test Centre — Theory Test, Practical Exam & the Examiner Bribe Hustle

### DIFF
--- a/src/main/java/ragamuffin/building/Material.java
+++ b/src/main/java/ragamuffin/building/Material.java
@@ -4346,7 +4346,37 @@ public enum Material {
      * One-use: interact (E) with a PCN-marked car while holding CLIVE_TERMINAL
      * to void the PCN (80% success chance).
      */
-    CLIVE_TERMINAL("Clive's Terminal");
+    CLIVE_TERMINAL("Clive's Terminal"),
+
+    // ── Issue #1205: Northfield DVSA Test Centre ──────────────────────────────
+
+    /**
+     * Driving Licence — a pink UK driving licence (DVLA format).
+     * Awarded on passing the practical test at the DVSA Test Centre, or obtained via
+     * the PENDING_TEST_RESULT_ITEM forgery route (30% fraud detection chance per use).
+     * Disables the unlicensed-driving penalty in NotorietySystem and unlocks DRIVING
+     * rank 4+ cap in StreetSkillSystem. Permanent item; not consumed on use.
+     * Tooltip: "Full UK driving licence. Sandra was reluctant but the Highway Code was clear."
+     */
+    DRIVING_LICENCE("Driving Licence"),
+
+    /**
+     * Theory Pass Certificate — a laminated DVSA theory pass certificate.
+     * Awarded on passing the theory test (≥8/10 questions correct) at the
+     * THEORY_TERMINAL_PROP. Required to book a practical test with Sandra.
+     * Single-use prerequisite; not consumed but checked on practical test booking.
+     * Tooltip: "Passed the theory. The examiner looked almost impressed."
+     */
+    THEORY_PASS_CERTIFICATE("Theory Pass Certificate"),
+
+    /**
+     * Pending Test Result — a manila envelope from the FILING_CABINET_PROP.
+     * Contains a forged driving test pass result. Acts as a DRIVING_LICENCE substitute
+     * but has a 30% chance each use that Sandra detects it as fraudulent:
+     * WantedSystem +2 stars, FRAUD recorded in CriminalRecord.
+     * Tooltip: "Someone's pending test result. Probably won't stand up to scrutiny."
+     */
+    PENDING_TEST_RESULT_ITEM("Pending Test Result");
 
     private final String displayName;
 
@@ -7111,6 +7141,14 @@ public enum Material {
                 return IconShape.BOX;         // heavy metal device
             case CLIVE_TERMINAL:
                 return IconShape.BOX;         // hand-held enforcement terminal
+
+            // Issue #1205: Northfield DVSA Test Centre
+            case DRIVING_LICENCE:
+                return IconShape.CARD;        // laminated pink licence card
+            case THEORY_PASS_CERTIFICATE:
+                return IconShape.FLAT_PAPER;  // printed certificate
+            case PENDING_TEST_RESULT_ITEM:
+                return IconShape.FLAT_PAPER;  // manila envelope
 
             default:
                 return IconShape.BOX;

--- a/src/main/java/ragamuffin/core/StreetSkillSystem.java
+++ b/src/main/java/ragamuffin/core/StreetSkillSystem.java
@@ -117,7 +117,14 @@ public class StreetSkillSystem {
         /** Issue #1153: Aerobics — trained at Sandra's Mon/Wed/Fri class at the Community Centre.
          *  Raw integer points (0–10). Improves rhythm prompt timing window:
          *  level 0–2: baseline 0.4s window; 3–5: 0.55s window; 6+: 0.70s window. */
-        AEROBICS
+        AEROBICS,
+
+        /** Issue #1205: Driving — earned via lessons with Keith (DRIVING_INSTRUCTOR) and
+         *  by completing the practical test. Raw integer XP; tier 4 cap unlocked only after
+         *  obtaining a DRIVING_LICENCE. Reduces fault penalties per tier during the practical:
+         *  tier 0 = baseline; tier 1 = −1 fault/collision; tier 2 = −2 fault/collision;
+         *  tier 3 = −3 fault/collision; tier 4 = −5 fault/collision (licence required). */
+        DRIVING
     }
 
     // ── Tier enum ─────────────────────────────────────────────────────────────

--- a/src/main/java/ragamuffin/entity/NPCType.java
+++ b/src/main/java/ragamuffin/entity/NPCType.java
@@ -2038,7 +2038,33 @@ public enum NPCType {
      * Speech: "Take a number." / "You'll need to fill in the form."
      *         / "Two working days and we'll write to you." / "Next, please."
      */
-    COUNCIL_RECEPTIONIST(20f, 0f, 0f, false);
+    COUNCIL_RECEPTIONIST(20f, 0f, 0f, false),
+
+    // ── Issue #1205: Northfield DVSA Test Centre ──────────────────────────────
+
+    /**
+     * Sandra — DVSA Examiner at the Northfield DVSA Test Centre.
+     * Sits behind the EXAMINER_DESK_PROP. Conducts theory tests (10 questions,
+     * 2 COIN fee) and practical tests (5 COIN, requires THEORY_PASS_CERTIFICATE).
+     * Can be bribed (CHARISMA ≥2 + 15 COIN, no witnesses within 6 blocks).
+     * Permanently refuses after a failed bribe attempt.
+     * Passive unless provoked; never hostile.
+     * Speech: "Next candidate please." / "Form an orderly queue."
+     *         / "I'm going to need your certificate before we can proceed."
+     */
+    DVSA_EXAMINER(30f, 0f, 0f, false),
+
+    /**
+     * Keith — Driving Instructor stationed outside the DVSA Test Centre.
+     * Stands near the INSTRUCTOR_CAR_PROP. Offers 60-second driving lesson
+     * sessions for 3 COIN/session; awards DRIVING XP +5 per lesson.
+     * After 3 lessons, applies −5 fault reduction on the player's next
+     * practical test. Passive; never hostile.
+     * Speech: "Right, mirrors — signal — manoeuvre."
+     *         / "Check your blind spot, son."
+     *         / "Three lessons and you'll be fine. Probably."
+     */
+    DRIVING_INSTRUCTOR(25f, 0f, 0f, false);
 
     private final float maxHealth;
     private final float attackDamage;   // Damage per hit to player

--- a/src/main/java/ragamuffin/ui/AchievementType.java
+++ b/src/main/java/ragamuffin/ui/AchievementType.java
@@ -3956,6 +3956,56 @@ public enum AchievementType {
         "Mic Drop",
         "Stole the mic mid-show. Bev is absolutely fuming.",
         1
+    ),
+
+    // ── Issue #1205: Northfield DVSA Test Centre ──────────────────────────────
+
+    /**
+     * Awarded when the player passes the DVSA theory test with ≥8/10 correct.
+     */
+    THEORY_PASSMARK(
+        "First Time Pass",
+        "You passed the theory test. Eight out of ten. The Highway Code is surprisingly violent.",
+        1
+    ),
+
+    /**
+     * Awarded when the player obtains a full DRIVING_LICENCE by passing the
+     * practical test with Sandra (≤15 faults).
+     */
+    ROAD_LEGAL(
+        "Road Legal",
+        "Full UK licence. Sandra looked almost proud. Almost.",
+        1
+    ),
+
+    /**
+     * Awarded when the player successfully bribes Sandra for an instant pass
+     * (CHARISMA ≥2 + 15 COIN, 70% success, no witnesses within 6 blocks).
+     */
+    PALM_GREASED(
+        "Cash in Hand",
+        "A brown envelope and a firm handshake. Sandra calls it a gift. The law calls it something else.",
+        1
+    ),
+
+    /**
+     * Awarded when the player completes 3 driving lessons with Keith.
+     */
+    BACKSEAT_DRIVER(
+        "Backseat Driver",
+        "Three lessons with Keith. He's given up correcting your mirror checks.",
+        1
+    ),
+
+    /**
+     * Awarded when a police NPC is spawned due to the unlicensed-driving penalty
+     * (player entered a car without a DRIVING_LICENCE).
+     */
+    DRIVING_WITHOUT_DUE_CARE(
+        "No Licence, No Problem",
+        "The police disagree. Twenty percent chance. You hit the twenty percent.",
+        1
     );
 
     private final String name;

--- a/src/main/java/ragamuffin/world/LandmarkType.java
+++ b/src/main/java/ragamuffin/world/LandmarkType.java
@@ -622,7 +622,19 @@ public enum LandmarkType {
      * Vehicle removal uses TaxiSystem vehicle-movement logic for towing animation.
      * Managed by TrafficWardenSystem.
      */
-    VEHICLE_IMPOUND;
+    VEHICLE_IMPOUND,
+
+    // ── Issue #1205: Northfield DVSA Test Centre ──────────────────────────────
+
+    /**
+     * Issue #1205: DVSA_TEST_CENTRE — the Northfield DVSA driving test centre on
+     * the industrial estate. A 10×8×3 pebble-dash building.
+     * Open Mon–Fri 08:00–17:00, Sat 08:00–13:00.
+     * Staffed by Sandra (DVSA_EXAMINER) at the desk and Keith (DRIVING_INSTRUCTOR)
+     * outside with a car.
+     * Managed by DrivingTestSystem.
+     */
+    DVSA_TEST_CENTRE;
 
     /**
      * Returns the display name shown on the building's sign.
@@ -717,6 +729,7 @@ public enum LandmarkType {
             case INFO_BROKER_PUB:       return "The Feathers";
             case COUNCIL_OFFICE:        return "Northfield Council Office";
             case VEHICLE_IMPOUND:       return "Vehicle Impound";
+            case DVSA_TEST_CENTRE:      return "Northfield DVSA Test Centre";
             default:                    return null; // No sign for parks, houses, etc.
         }
     }

--- a/src/main/java/ragamuffin/world/PropType.java
+++ b/src/main/java/ragamuffin/world/PropType.java
@@ -2602,7 +2602,40 @@ public enum PropType {
      * Grab while Bev is distracted (10-second window after each song). Yields
      * MICROPHONE item. Destroyed by 2 punches; yields MICROPHONE material.
      */
-    MICROPHONE_PROP(0.20f, 1.20f, 0.20f, 2, Material.MICROPHONE);
+    MICROPHONE_PROP(0.20f, 1.20f, 0.20f, 2, Material.MICROPHONE),
+
+    // ── Issue #1205: Northfield DVSA Test Centre ──────────────────────────────
+
+    /**
+     * THEORY_TERMINAL_PROP — a beige desktop PC on a particleboard desk.
+     * Interact (E) to start a theory test (costs 2 COIN, 10 questions from pool of 30).
+     * Each question is multiple-choice (1–4 input); ≥8/10 correct = pass.
+     * Destroyed by 5 punches; yields SCRAP_METAL.
+     */
+    THEORY_TERMINAL_PROP(0.70f, 1.10f, 0.50f, 5, Material.SCRAP_METAL),
+
+    /**
+     * EXAMINER_DESK_PROP — Sandra's examination desk at the DVSA Test Centre.
+     * Interact (E) to speak with Sandra: book a practical test, attempt a bribe,
+     * or check test status. Destroyed by 8 punches; yields WOOD.
+     */
+    EXAMINER_DESK_PROP(1.40f, 0.80f, 0.60f, 8, Material.WOOD),
+
+    /**
+     * INSTRUCTOR_CAR_PROP — Keith's dual-control Ford Fiesta parked outside the
+     * test centre. Interact (E) to start a driving lesson with Keith (3 COIN/session).
+     * Not driveable by the player independently. Destroyed by 10 punches; yields
+     * SCRAP_METAL. Exempt from TrafficWarden PCNs.
+     */
+    INSTRUCTOR_CAR_PROP(2.50f, 1.50f, 4.50f, 10, Material.SCRAP_METAL),
+
+    /**
+     * FILING_CABINET_PROP — a grey metal filing cabinet in the back office.
+     * LOCKPICK required; 3 hits to open; yields PENDING_TEST_RESULT_ITEM (forged cert).
+     * 30% chance Sandra flags it as fraud each use: WantedSystem +2 stars, FRAUD crime.
+     * Destroyed by 5 punches; yields SCRAP_METAL.
+     */
+    FILING_CABINET_PROP(0.50f, 1.30f, 0.40f, 5, Material.SCRAP_METAL);
 
     // ─────────────────────────────────────────────────────────────────────────
     // Issue #719: Collision and destructibility data


### PR DESCRIPTION
## Summary
Automated fix for issue #1205.

## Changes
- Fix #1205: automated fix

Closes #1205