### PR TITLE
Fix #1240: Add Northfield NHS Blood Donation Session — Mobile Unit, Biscuit Table & the Black Market Plasma Hustle

### DIFF
--- a/src/main/java/ragamuffin/building/Material.java
+++ b/src/main/java/ragamuffin/building/Material.java
@@ -4752,7 +4752,38 @@ public enum Material {
      * Present at the AGM to expose him: Notoriety −15, Hicks flees, newspaper headline.
      * Tooltip: "Council planning application with someone else's signature on it."
      */
-    INCRIMINATING_DOCUMENT("Incriminating Document");
+    INCRIMINATING_DOCUMENT("Incriminating Document"),
+
+    // ── Issue #1240: Northfield NHS Blood Donation Session ────────────────────
+
+    /**
+     * BLOOD_BAG — a sealed NHS blood donation bag.
+     * Dropped from BLOOD_FRIDGE_PROP in the mobile unit van. Fence value 10 COIN.
+     * Tooltip: "Still warm. The label says 'O+'. Handle with care."
+     */
+    BLOOD_BAG("Blood Bag"),
+
+    /**
+     * DONOR_QUESTIONNAIRE — the pre-donation eligibility form on the clipboard.
+     * Pick up from DONOR_QUESTIONNAIRE_PROP. Used at PHOTOCOPIER_PROP to craft
+     * FORGED_DONOR_QUESTIONNAIRE. Tooltip: "A checklist of awkward questions."
+     */
+    DONOR_QUESTIONNAIRE("Donor Questionnaire"),
+
+    /**
+     * FORGED_DONOR_QUESTIONNAIRE — a photocopied, altered eligibility form.
+     * Crafted from DONOR_QUESTIONNAIRE + BLANK_FORM at PHOTOCOPIER_PROP.
+     * Present to Brenda when ineligible: 70% success if Tyler not watching.
+     * Tooltip: "All the right boxes are ticked. You ticked them yourself."
+     */
+    FORGED_DONOR_QUESTIONNAIRE("Forged Donor Questionnaire"),
+
+    /**
+     * ORANGE_SQUASH — the complimentary drink given after donation.
+     * Heals +5 HP. Awarded automatically after legitimate donation.
+     * Tooltip: "Warm, slightly flat. Still appreciated."
+     */
+    ORANGE_SQUASH("Orange Squash");
 
     private final String displayName;
 
@@ -5854,6 +5885,15 @@ public enum Material {
             case BACK_ROOM_KEY:         return c(0.75f, 0.65f, 0.30f);  // Brass yellow
             case INCRIMINATING_DOCUMENT: return cs(0.92f, 0.90f, 0.78f, // Cream paper
                                                    0.60f, 0.10f, 0.10f); // Red stamp
+
+            // Issue #1240: Northfield NHS Blood Donation Session
+            case BLOOD_BAG:             return cs(0.75f, 0.08f, 0.08f,  // Blood red bag
+                                                  0.88f, 0.88f, 0.92f); // Clear plastic
+            case DONOR_QUESTIONNAIRE:   return cs(0.95f, 0.95f, 0.92f,  // White form
+                                                  0.20f, 0.50f, 0.20f); // NHS green header
+            case FORGED_DONOR_QUESTIONNAIRE: return cs(0.92f, 0.92f, 0.88f, // Slightly off-white
+                                                  0.20f, 0.50f, 0.20f); // NHS green header
+            case ORANGE_SQUASH:         return c(0.95f, 0.55f, 0.10f);  // Orange squash colour
 
             default:             return c(0.5f, 0.5f, 0.5f);
         }
@@ -7636,6 +7676,16 @@ public enum Material {
                 return IconShape.FLAT_PAPER;  // small brass Yale key
             case INCRIMINATING_DOCUMENT:
                 return IconShape.FLAT_PAPER;  // folded planning document
+
+            // Issue #1240: Northfield NHS Blood Donation Session
+            case BLOOD_BAG:
+                return IconShape.BOX;         // sealed blood donation bag
+            case DONOR_QUESTIONNAIRE:
+                return IconShape.FLAT_PAPER;  // clipboard eligibility form
+            case FORGED_DONOR_QUESTIONNAIRE:
+                return IconShape.FLAT_PAPER;  // photocopied altered form
+            case ORANGE_SQUASH:
+                return IconShape.CYLINDER;    // plastic cup of squash
 
             default:
                 return IconShape.BOX;

--- a/src/main/java/ragamuffin/entity/NPCType.java
+++ b/src/main/java/ragamuffin/entity/NPCType.java
@@ -2235,7 +2235,17 @@ public enum NPCType {
      * Issue #1235: RAFFLE_ORGANISER — Irene, who runs the Friday-evening meat raffle.
      * Sells raffle tickets and draws numbers. Non-hostile.
      */
-    RAFFLE_ORGANISER(25f, 0f, 0f, false);
+    RAFFLE_ORGANISER(25f, 0f, 0f, false),
+
+    // ── Issue #1240: Northfield NHS Blood Donation Session ────────────────────
+
+    /**
+     * Issue #1240: NHS_DONOR_COORDINATOR — Brenda, the mobile unit coordinator.
+     * Stationed at BLOOD_DONATION_VAN_PROP in the Community Centre car park every
+     * 14 in-game days (Wednesday 09:00–17:00). Manages the eligibility questionnaire
+     * and oversees the donation session. Non-hostile.
+     */
+    NHS_DONOR_COORDINATOR(30f, 0f, 0f, false);
 
     private final float maxHealth;
     private final float attackDamage;   // Damage per hit to player

--- a/src/main/java/ragamuffin/ui/AchievementType.java
+++ b/src/main/java/ragamuffin/ui/AchievementType.java
@@ -4319,6 +4319,69 @@ public enum AchievementType {
         "Grass of the Year",
         "Tipped off a traffic warden during the school run. Earned 2 COIN. Worth it.",
         1
+    ),
+
+    // ── Issue #1240: Northfield NHS Blood Donation Session ────────────────────
+
+    /**
+     * Awarded on first legitimate blood donation to Brenda (NHS_DONOR_COORDINATOR).
+     * You sat in the recliner. You gave blood. You ate a biscuit. Northfield is proud.
+     */
+    GOOD_CITIZEN(
+        "Good Citizen",
+        "Donated blood at the NHS mobile unit. Brenda said you were very brave.",
+        1
+    ),
+
+    /**
+     * Awarded when the player completes 3 legitimate donations across separate sessions
+     * (84-day cooldown enforced between each).
+     * You are a regular. They know your name. They save you the good biscuits.
+     */
+    REGULAR_DONOR(
+        "Regular Donor",
+        "Donated blood three times. They've put your name on the biscuit tin.",
+        3
+    ),
+
+    /**
+     * Awarded when the player successfully presents a FORGED_DONOR_QUESTIONNAIRE to Brenda.
+     * The form was perfect. Tyler wasn't looking. You got a biscuit anyway.
+     */
+    FORGED_THEIR_WAY_TO_A_BISCUIT(
+        "Forged Their Way to a Biscuit",
+        "Submitted a forged questionnaire and got away with it. Worth it for the Hobnob.",
+        1
+    ),
+
+    /**
+     * Awarded when the player donates twice in one session using DisguiseSystem (score ≥ 3).
+     * Tyler didn't recognise you. The nurses did. They let it go — you seemed enthusiastic.
+     */
+    TWICE_THE_HERO(
+        "Twice the Hero",
+        "Donated blood twice in one session. Tyler was fooled. Brenda had her suspicions.",
+        1
+    ),
+
+    /**
+     * Awarded when the player steals the BISCUIT_TABLE_PROP tin while unobserved.
+     * Eight biscuits. Gone. Northfield's most audacious heist.
+     */
+    BISCUIT_TIN_BANDIT(
+        "Biscuit Tin Bandit",
+        "Nicked the donation tin when nobody was looking. Eight biscuits. No remorse.",
+        1
+    ),
+
+    /**
+     * Awarded when the player steals 3 or more BLOOD_BAGs from BLOOD_FRIDGE_PROP in one session.
+     * The van was raided. The Gazette ran it on the front page. You were long gone.
+     */
+    PLASMA_KING(
+        "Plasma King",
+        "Stole three blood bags from the NHS van. The Gazette called it 'audacious'.",
+        1
     );
 
     private final String name;


### PR DESCRIPTION
## Summary
Automated fix for issue #1240.

## Changes
- Fix #1240: automated fix

Closes #1240