### PR TITLE
Fix #1265: Add Northfield Loan Shark — Big Mick's Doorstep Lending, Debt Spiral & the Debt Collector Hustle

### DIFF
--- a/src/main/java/ragamuffin/building/Material.java
+++ b/src/main/java/ragamuffin/building/Material.java
@@ -4952,7 +4952,27 @@ public enum Material {
      * Can be fenced at StreetEconomySystem for 3 COIN, or kept for bragging rights.
      * Tooltip: "You beat a load of boy racers. Outstanding."
      */
-    RACING_TROPHY("Racing Trophy");
+    RACING_TROPHY("Racing Trophy"),
+
+    // ── Issue #1265: Northfield Loan Shark — Big Mick's Doorstep Lending ─────
+
+    /**
+     * LOAN_AGREEMENT — a crumpled, barely-legible two-page contract issued by
+     * Big Mick when the player borrows money. Contains the loan amount, ruinous
+     * APR, and a "security clause" written in tiny print.
+     * Given to the player on borrow(); surrendered on full repayment.
+     * Tooltip: "The small print says he can take your stuff. He wasn't joking."
+     */
+    LOAN_AGREEMENT("Loan Agreement"),
+
+    /**
+     * DEBT_LEDGER — Big Mick's handwritten accounts book, kept in a locked desk
+     * at the Loan Shark Office. Lists every outstanding debt with names, amounts,
+     * and collection notes. Extremely incriminating.
+     * Sellable to the Marchetti Crew contact for 30 COIN (clears player debt).
+     * Tooltip: "Names, numbers, the lot. Half the estate is in here."
+     */
+    DEBT_LEDGER("Debt Ledger");
 
     private final String displayName;
 
@@ -6091,6 +6111,12 @@ public enum Material {
             case RACING_TROPHY:         return cs(0.90f, 0.75f, 0.20f,  // Gold trophy
                                                   0.60f, 0.45f, 0.15f); // Dark gold base
 
+            // Issue #1265: Northfield Loan Shark — Big Mick's Doorstep Lending
+            case LOAN_AGREEMENT:        return cs(0.95f, 0.92f, 0.80f,  // Yellowed paper
+                                                  0.70f, 0.15f, 0.10f); // Red "AGREEMENT" stamp
+            case DEBT_LEDGER:           return cs(0.20f, 0.20f, 0.25f,  // Dark navy cover
+                                                  0.85f, 0.75f, 0.30f); // Gold lettering
+
             default:             return c(0.5f, 0.5f, 0.5f);
         }
     }
@@ -6773,6 +6799,9 @@ public enum Material {
             // Issue #1263: Northfield Illegal Street Racing
             case NITROUS_CANISTER:
             case RACING_TROPHY:
+            // Issue #1265: Northfield Loan Shark — Big Mick's Doorstep Lending
+            case LOAN_AGREEMENT:
+            case DEBT_LEDGER:
                 return true;
             default:
                 return false;

--- a/src/main/java/ragamuffin/core/CriminalRecord.java
+++ b/src/main/java/ragamuffin/core/CriminalRecord.java
@@ -754,7 +754,16 @@ public class CriminalRecord {
          * blocks of the racing cones when the police shutdown occurs (+1 Wanted star).
          * Penalty: Notoriety +5 per participation. WantedSystem stars per spec.
          */
-        ILLEGAL_STREET_RACING("Illegal street racing");
+        ILLEGAL_STREET_RACING("Illegal street racing"),
+
+        // ── Issue #1265: Northfield Loan Shark — Big Mick's Doorstep Lending ─────
+
+        /**
+         * Recorded when the player punches a DEBT_COLLECTOR NPC sent by Big Mick.
+         * Adds +2 Wanted stars and is logged by LoanSharkSystem when the collector
+         * is struck.
+         */
+        LOAN_SHARK_ASSAULT("Loan shark collector assault");
 
         private final String displayName;
 

--- a/src/main/java/ragamuffin/core/RumourType.java
+++ b/src/main/java/ragamuffin/core/RumourType.java
@@ -588,5 +588,22 @@ public enum RumourType {
     /** "Some dodgy business at the racing last night — someone messed with the nitrous."
      * — seeded by StreetRacingSystem on successful sabotage (SCREWDRIVER on competitor car).
      * Spreads via BOY_RACER NPCs within the meet. Player identified if caught by car owner. */
-    RACING_SABOTAGE;
+    RACING_SABOTAGE,
+
+    // ── Issue #1265: Northfield Loan Shark — Big Mick's Doorstep Lending ─────────
+
+    /** "Big Mick's lads are looking for someone who owes him — seen them round the estate."
+     * — seeded by LoanSharkSystem when a loan becomes overdue (first missed repayment day).
+     * Spreads via PUBLIC and PENSIONER NPCs. Causes DEBT_COLLECTOR to follow the player. */
+    LOAN_SHARK_LOOKING_FOR_YOU,
+
+    /** "Heard someone paid Big Mick back in full — he's moved on to the next mug."
+     * — seeded by LoanSharkSystem when the player fully repays the loan (principal + interest).
+     * Spreads via PUBLIC NPCs; despawns DEBT_COLLECTOR. */
+    LOAN_PAID_OFF,
+
+    /** "Big Mick's been sniffing round the benefits office again — looking for someone skint."
+     * — seeded by DWPSystem on benefit payment day when the player has an outstanding loan.
+     * Spreads via PUBLIC and JOB_CENTRE_CLERK NPCs within 40 blocks of the JobCentre. */
+    BIG_MICK_DEBT;
 }

--- a/src/main/java/ragamuffin/ui/AchievementType.java
+++ b/src/main/java/ragamuffin/ui/AchievementType.java
@@ -4596,6 +4596,50 @@ public enum AchievementType {
         "Grass",
         "Rang the plod. Shane'll find out. They always find out.",
         1
+    ),
+
+    // ── Issue #1265: Northfield Loan Shark — Big Mick's Doorstep Lending ─────
+
+    /**
+     * Awarded (instant) when the player takes out their first loan from Big Mick.
+     * Triggers on LoanSharkSystem.borrow() with any tier. Welcome to the red.
+     */
+    IN_THE_RED(
+        "In the Red",
+        "Borrowed off Big Mick. Everyone does it once. Most do it twice.",
+        1
+    ),
+
+    /**
+     * Awarded (instant) when the player's debt reaches the compounded maximum
+     * (2× original loan) and the collector seizes a hotbar item.
+     * The point of no return.
+     */
+    SPIRAL(
+        "Spiral",
+        "Debt hit the cap. Collector's been round. You knew it would come to this.",
+        1
+    ),
+
+    /**
+     * Awarded (instant) when the player fully repays their loan (principal + all
+     * accrued interest) via LoanSharkSystem.repay(). Clean slate — for now.
+     */
+    CLEARED_UP(
+        "Cleared Up",
+        "Paid Big Mick back every penny. He's already looking for your replacement.",
+        1
+    ),
+
+    /**
+     * Awarded (instant) when the player completes the Ledger Job hustle: steals the
+     * DEBT_LEDGER from Big Mick's desk and sells it to the Marchetti Crew contact.
+     * Clears the debt but triggers 2 THUG NPCs for 5 in-game days.
+     */
+    BIG_MICK_BOUNCED(
+        "Big Mick Bounced",
+        "Flogged his ledger to the Marchettis. Debt gone. Thugs incoming. Worth it.",
+        1
     );
 
     private final String name;


### PR DESCRIPTION
## Summary
Automated fix for issue #1265.

## Changes
- Fix #1265: automated fix

Closes #1265