### PR TITLE
Fix #1303: Add Northfield Dave's Carpets — Perpetual Closing-Down Sale, Sofa Hustle & Trading Standards Investigation

### DIFF
--- a/src/main/java/ragamuffin/building/Material.java
+++ b/src/main/java/ragamuffin/building/Material.java
@@ -5161,7 +5161,44 @@ public enum Material {
      * 5× BIG_ISSUE_MAG. Can be pickpocketed (55% detection base; −20% with
      * STREET_SMARTS ≥ 5).
      */
-    CANVAS_BAG("Canvas Bag");
+    CANVAS_BAG("Canvas Bag"),
+
+    // ── Issue #1303: Northfield Dave's Carpets ────────────────────────────────
+
+    /**
+     * CARPET_OFFCUT — a remnant piece of carpet from Dave's stockroom.
+     * Purchased for 4 COIN or looted (×2–4) from a CARPET_ROLL_PROP when Kev is distracted.
+     * Placed as flooring in the squat grants a warmth bonus (+2 Vibe/block via SquatFurnishingTracker).
+     */
+    CARPET_OFFCUT("Carpet Offcut"),
+
+    /**
+     * SOFA — a bulky second-hand sofa purchased from Dave for 12 COIN.
+     * Can be transported to a squat/property using a SACK_TRUCK.
+     * Grants +20 comfort (Vibe) via SquatFurnishingTracker on delivery.
+     * There is a 45% witness-calls-police risk while transporting it.
+     */
+    SOFA("Sofa"),
+
+    /**
+     * CLOSING_DOWN_FLYER — crafted from NEWSPAPER + MARKER_PEN.
+     * Hand to NPCs to refer them to Dave for +1 COIN commission each.
+     * Also used as a prop when setting up the player's own fake closing-down pitch.
+     */
+    CLOSING_DOWN_FLYER("Closing-Down Flyer"),
+
+    /**
+     * SACK_TRUCK — a fold-flat trolley purchased for 6 COIN from Dave or looted from
+     * the SACK_TRUCK_PROP in the stockroom. Required to transport a SOFA.
+     * Looting from stockroom requires Kev to be distracted.
+     */
+    SACK_TRUCK("Sack Truck"),
+
+    /**
+     * CARPET_SAMPLE_BOOK — a large ring-binder of carpet samples taken from the shop floor.
+     * Can be sold to FenceSystem for 3 COIN or used as a prop in the player's fake pitch.
+     */
+    CARPET_SAMPLE_BOOK("Carpet Sample Book");
 
     private final String displayName;
 
@@ -8226,6 +8263,18 @@ public enum Material {
                 return IconShape.FLAT_PAPER;  // counterfeit magazine
             case CANVAS_BAG:
                 return IconShape.BOX;         // shoulder bag
+
+            // Issue #1303: Northfield Dave's Carpets
+            case CARPET_OFFCUT:
+                return IconShape.BOX;         // rolled carpet offcut
+            case SOFA:
+                return IconShape.BOX;         // bulky sofa
+            case CLOSING_DOWN_FLYER:
+                return IconShape.FLAT_PAPER;  // printed flyer
+            case SACK_TRUCK:
+                return IconShape.BOX;         // fold-flat trolley
+            case CARPET_SAMPLE_BOOK:
+                return IconShape.BOX;         // ring-binder of samples
 
             default:
                 return IconShape.BOX;

--- a/src/main/java/ragamuffin/core/RumourType.java
+++ b/src/main/java/ragamuffin/core/RumourType.java
@@ -784,5 +784,24 @@ public enum RumourType {
      * Spreads via CHUGGER_LEADER (Tracy), PUBLIC, and POLICE NPCs within 30 blocks.
      * Triggers Notoriety +6, WantedSystem +1, CHARITY_FRAUD in CriminalRecord.
      * NewspaperSystem headline eligible. */
-    CHARITY_FRAUD_RUMOUR;
+    CHARITY_FRAUD_RUMOUR,
+
+    // ── Issue #1303: Northfield Dave's Carpets ────────────────────────────────
+
+    /** "Heard someone's been brokering deals for Dave's Carpets — earning a coin a head bringing punters in."
+     * — seeded by CarpetShopSystem when the player successfully refers an NPC (5th referral).
+     * Spreads via STREET_LAD and PUBLIC NPCs; StreetSkillSystem +TRADING XP. */
+    DEAL_BROKER,
+
+    /** "Word is someone nicked a load of carpet from Dave's stockroom while the driver wasn't looking."
+     * — seeded by CarpetShopSystem when the player loots the CARPET_ROLL_PROP.
+     * Spreads via PUBLIC and STREET_LAD NPCs within 30 blocks.
+     * Triggers Notoriety +4, WantedSystem +1, THEFT in CriminalRecord.
+     * NewspaperSystem headline eligible. */
+    CARPET_THIEF,
+
+    /** "Apparently someone grassed Dave's Carpets up to Trading Standards — about bloody time."
+     * — seeded by CarpetShopSystem when the player reports Dave to Sandra.
+     * Spreads via PUBLIC, STREET_LAD NPCs; FactionSystem: Marchetti −1, Street Lads +1. */
+    DAVE_REPORTED;
 }

--- a/src/main/java/ragamuffin/entity/NPCType.java
+++ b/src/main/java/ragamuffin/entity/NPCType.java
@@ -2452,7 +2452,40 @@ public enum NPCType {
      * </ul>
      * HP: 25f, attack: 0f, cooldown: 0f, hostile: false.
      */
-    BIG_ISSUE_VENDOR(25f, 0f, 0f, false);
+    BIG_ISSUE_VENDOR(25f, 0f, 0f, false),
+
+    // ── Issue #1303: Northfield Dave's Carpets ────────────────────────────────
+
+    /**
+     * CARPET_SALESMAN — Dave Hogan, proprietor of Dave's Carpets.
+     * <ul>
+     *   <li>Stands outside the shop 09:00–17:00 Mon–Sat cycling through closing-down pitches.</li>
+     *   <li>Sells SOFA, CARPET_OFFCUT, SACK_TRUCK; goes DEFLATED for 24h after TRADING_STANDARDS_WARNING.</li>
+     *   <li>Enters DEFLATED state when reported to Trading Standards (Sandra's inspection).</li>
+     * </ul>
+     * HP: 25f, attack: 0f, cooldown: 0f, hostile: false.
+     */
+    CARPET_SALESMAN(25f, 0f, 0f, false),
+
+    /**
+     * DELIVERY_DRIVER — Kev, who mans the stockroom at Dave's Carpets.
+     * <ul>
+     *   <li>Present during shop hours; can be distracted with a CHOCOLATE_BAR for 90 seconds.</li>
+     *   <li>Guards the CARPET_ROLL_PROP in the stockroom.</li>
+     * </ul>
+     * HP: 25f, attack: 0f, cooldown: 0f, hostile: false.
+     */
+    DELIVERY_DRIVER(25f, 0f, 0f, false),
+
+    /**
+     * TRADING_STANDARDS_OFFICER — Sandra, the Trading Standards inspector.
+     * <ul>
+     *   <li>Spawned by CarpetShopSystem when the player reports Dave's closing-down claim (3rd repeat).</li>
+     *   <li>Issues TRADING_STANDARDS_WARNING prop; triggers Dave's DEFLATED state.</li>
+     * </ul>
+     * HP: 20f, attack: 0f, cooldown: 0f, hostile: false.
+     */
+    TRADING_STANDARDS_OFFICER(20f, 0f, 0f, false);
 
     private final float maxHealth;
     private final float attackDamage;   // Damage per hit to player

--- a/src/main/java/ragamuffin/ui/AchievementType.java
+++ b/src/main/java/ragamuffin/ui/AchievementType.java
@@ -4972,6 +4972,71 @@ public enum AchievementType {
         "Tip-Off",
         "You warned Bert about the inspector. He owes you one. He probably won't pay.",
         1
+    ),
+
+    // ── Issue #1303: Northfield Dave's Carpets ────────────────────────────────
+
+    /**
+     * Awarded when the player earns commission by referring 5 NPCs to Dave's Carpets.
+     * Each referral with a CLOSING_DOWN_FLYER yields +1 COIN.
+     * Seeds DEAL_BROKER rumour on unlock.
+     */
+    CARPET_KING(
+        "Carpet King",
+        "Five suckers walked through Dave's door because of you. He's still closing down.",
+        5
+    ),
+
+    /**
+     * Awarded when the player delivers a SOFA to a squat AND has CARPET_OFFCUT flooring placed.
+     * Requires SACK_TRUCK for transport. +20 Vibe via SquatFurnishingTracker.
+     */
+    INTERIOR_DECORATOR(
+        "Interior Decorator",
+        "Sofa delivered. Carpet down. The squat has never looked so grim.",
+        1
+    ),
+
+    /**
+     * Awarded when the player loots the CARPET_ROLL_PROP while Kev is distracted.
+     * Yields CARPET_OFFCUT x2-4 and SACK_TRUCK. Seeds CARPET_THIEF rumour.
+     */
+    FIVE_FINGER_DISCOUNT(
+        "Five-Finger Discount",
+        "Kev had a Twix. You had a carpet roll. Fair trade, really.",
+        1
+    ),
+
+    /**
+     * Awarded when the player earns 8 COIN from their own fake closing-down pitch
+     * without Keith (MARKET_INSPECTOR) catching them.
+     * Requires CLOSING_DOWN_FLYERs and 4 sales before inspector spawn.
+     */
+    COPYCAT_DAVE(
+        "Copycat Dave",
+        "You set up your own closing-down sale. Dave's been doing it three years. You managed four sales.",
+        1
+    ),
+
+    /**
+     * Awarded when the player successfully reports Dave to Sandra (Trading Standards).
+     * Dave enters DEFLATED state for 24h; TRADING_STANDARDS_WARNING prop placed.
+     * Seeds DAVE_REPORTED rumour.
+     */
+    REPORTED_DAVE(
+        "Reported Dave",
+        "You grassed up Dave to Trading Standards. Sandra was not amused. Dave was less so.",
+        1
+    ),
+
+    /**
+     * Awarded when the player interacts with Dave while he is in DEFLATED state
+     * (after Sandra's visit). Dave delivers a mournful speech.
+     */
+    STANDING_CUSTOMER_DAVE(
+        "Standing Customer",
+        "You visited Dave while he was at rock bottom. He appreciated it. Sort of.",
+        1
     );
 
     private final String name;

--- a/src/main/java/ragamuffin/world/PropType.java
+++ b/src/main/java/ragamuffin/world/PropType.java
@@ -3123,7 +3123,46 @@ public enum PropType {
      * Dropped item: CHARITY_CLIPBOARD (represents the leftover paperwork).
      * 1.50×0.90×0.60; hitsToBreak = 4 (yields CHARITY_CLIPBOARD).
      */
-    CHARITY_CLIPBOARD_STAND_PROP(1.50f, 0.90f, 0.60f, 4, Material.CHARITY_CLIPBOARD);
+    CHARITY_CLIPBOARD_STAND_PROP(1.50f, 0.90f, 0.60f, 4, Material.CHARITY_CLIPBOARD),
+
+    // ── Issue #1303: Northfield Dave's Carpets ────────────────────────────────
+
+    /**
+     * CLOSING_DOWN_BANNER_PROP — the sun-bleached banner draped across Dave's shopfront:
+     * "CLOSING DOWN — EVERYTHING MUST GO!!"
+     * Decorative; clicking it records a closing-down claim observation.
+     * 3.00×1.00×0.10; hitsToBreak = 2 (yields CARPET_OFFCUT).
+     */
+    CLOSING_DOWN_BANNER_PROP(3.00f, 1.00f, 0.10f, 2, Material.CARPET_OFFCUT),
+
+    /**
+     * CARPET_ROLL_PROP — a large roll of carpet in the stockroom.
+     * Lootable when Kev is distracted; yields CARPET_OFFCUT ×2–4 (random).
+     * 2.00×0.60×0.60; hitsToBreak = 3 (yields CARPET_OFFCUT).
+     */
+    CARPET_ROLL_PROP(2.00f, 0.60f, 0.60f, 3, Material.CARPET_OFFCUT),
+
+    /**
+     * SOFA_PROP — a second-hand sofa on the shop floor.
+     * Becomes a SOFA item in inventory after purchase; or can be physically pushed
+     * using SACK_TRUCK_PROP mechanics.
+     * 2.00×0.90×0.90; hitsToBreak = 8 (yields SOFA).
+     */
+    SOFA_PROP(2.00f, 0.90f, 0.90f, 8, Material.SOFA),
+
+    /**
+     * SACK_TRUCK_PROP — a fold-flat trolley in the stockroom.
+     * Interacting (E) adds a SACK_TRUCK to inventory. Lootable when Kev is distracted.
+     * 0.50×1.40×0.40; hitsToBreak = 4 (yields SACK_TRUCK).
+     */
+    SACK_TRUCK_PROP(0.50f, 1.40f, 0.40f, 4, Material.SACK_TRUCK),
+
+    /**
+     * TRADING_STANDARDS_WARNING — the formal warning notice issued by Sandra after Dave's
+     * claim is reported. Placed on the shopfront by Sandra; causes Dave to enter DEFLATED state.
+     * 0.60×0.40×0.05; hitsToBreak = 1 (yields null — just disappears).
+     */
+    TRADING_STANDARDS_WARNING(0.60f, 0.40f, 0.05f, 1, null);
 
     // ─────────────────────────────────────────────────────────────────────────
     // Issue #719: Collision and destructibility data


### PR DESCRIPTION
## Summary
Automated fix for issue #1303.

## Changes
- Fix #1303: automated fix

Closes #1303