### PR TITLE
Fix #1305: Fix duplicate enum definitions in NPCType and AchievementType

### DIFF
--- a/src/main/java/ragamuffin/entity/NPCType.java
+++ b/src/main/java/ragamuffin/entity/NPCType.java
@@ -2468,14 +2468,14 @@ public enum NPCType {
     CARPET_SALESMAN(25f, 0f, 0f, false),
 
     /**
-     * DELIVERY_DRIVER — Kev, who mans the stockroom at Dave's Carpets.
+     * CARPET_STOCKROOM_WORKER — Kev, who mans the stockroom at Dave's Carpets.
      * <ul>
      *   <li>Present during shop hours; can be distracted with a CHOCOLATE_BAR for 90 seconds.</li>
      *   <li>Guards the CARPET_ROLL_PROP in the stockroom.</li>
      * </ul>
      * HP: 25f, attack: 0f, cooldown: 0f, hostile: false.
      */
-    DELIVERY_DRIVER(25f, 0f, 0f, false),
+    CARPET_STOCKROOM_WORKER(25f, 0f, 0f, false),
 
     /**
      * TRADING_STANDARDS_OFFICER — Sandra, the Trading Standards inspector.

--- a/src/main/java/ragamuffin/ui/AchievementType.java
+++ b/src/main/java/ragamuffin/ui/AchievementType.java
@@ -5001,7 +5001,7 @@ public enum AchievementType {
      * Awarded when the player loots the CARPET_ROLL_PROP while Kev is distracted.
      * Yields CARPET_OFFCUT x2-4 and SACK_TRUCK. Seeds CARPET_THIEF rumour.
      */
-    FIVE_FINGER_DISCOUNT(
+    CARPET_ROLL_HEIST(
         "Five-Finger Discount",
         "Kev had a Twix. You had a carpet roll. Fair trade, really.",
         1


### PR DESCRIPTION
## Summary
Automated fix for issue #1305.

## Changes
- Fix #1305: automated fix

Closes #1305