### PR TITLE
Fix #1353: Add Northfield Amateur Dramatics Society — Blood Brothers, the Costume Heist & the Opening Night Disaster

### DIFF
--- a/src/main/java/ragamuffin/building/Material.java
+++ b/src/main/java/ragamuffin/building/Material.java
@@ -5684,7 +5684,45 @@ public enum Material {
      * or fenceable for 1 COIN each.
      * Tooltip: "Needs a firm hand and the right fuse."
      */
-    CHRISTMAS_LIGHTS_BULB("Christmas Lights Bulb");
+    CHRISTMAS_LIGHTS_BULB("Christmas Lights Bulb"),
+
+    // ── Issue #1353: Northfield Amateur Dramatics Society ─────────────────────
+
+    /**
+     * STAGE_COSTUME — a theatrical costume from the NAODS production of Blood Brothers.
+     * Gives −2 police suspicion while worn (costume = 'not a criminal'). Flips to +1
+     * suspicion if player is Wanted ≥ 2. Non-cast wearers are spotted by NAODS_MEMBER
+     * NPCs with a 40% chance, triggering a confrontation. 3–5 costumes are stored in the
+     * lockpickable COSTUME_CUPBOARD_PROP. Sellable at charity shop for 3 COIN or via
+     * fence for 8 COIN.
+     * Tooltip: "You could be anyone in this. That's rather the point."
+     */
+    STAGE_COSTUME("Stage Costume"),
+
+    /**
+     * REHEARSAL_SCHEDULE — a printed rehearsal timetable issued to cast members by
+     * Patricia (DRAMA_DIRECTOR). Sets the NAODS_MEMBER flag on the player and confirms
+     * rehearsal nights (Wed/Thu 19:00–22:00). Leaving a rehearsal early removes the
+     * player from the cast.
+     * Tooltip: "Wednesday and Thursday. Don't be late."
+     */
+    REHEARSAL_SCHEDULE("Rehearsal Schedule"),
+
+    /**
+     * FORGED_TICKET — a forged NAODS opening night ticket craftable from
+     * PRINTER_PAPER + INK_BOTTLE. Admits entry to the production at a saving of 2 COIN.
+     * 30% chance of being caught at the TICKET_BOOTH_PROP, recording TICKET_FRAUD.
+     * Tooltip: "Printed on a home printer. It'll probably work."
+     */
+    FORGED_TICKET("Forged Ticket"),
+
+    /**
+     * PROP_GUN — a realistic-looking stage prop revolver used in the Blood Brothers
+     * production. Can be swapped with AIRGUN as part of Mario's sabotage plan, causing
+     * chaos on stage. Stored in the PROP_GUN_PROP cabinet.
+     * Tooltip: "It's not real. Probably best not to wave it around, though."
+     */
+    PROP_GUN("Prop Gun");
 
     private final String displayName;
 
@@ -6957,6 +6995,16 @@ public enum Material {
             case CHRISTMAS_LIGHTS_BULB: return cs(0.95f, 0.80f, 0.10f,  // Warm yellow glow
                                                   0.85f, 0.25f, 0.10f); // Red base
 
+            // Issue #1353: Northfield Amateur Dramatics Society
+            case STAGE_COSTUME:         return cs(0.75f, 0.20f, 0.55f,  // Theatrical purple
+                                                  0.95f, 0.90f, 0.80f); // Cream lace trim
+            case REHEARSAL_SCHEDULE:    return cs(0.92f, 0.92f, 0.88f,  // Off-white paper
+                                                  0.20f, 0.35f, 0.60f); // Blue ink header
+            case FORGED_TICKET:         return cs(0.90f, 0.85f, 0.70f,  // Cream ticket card
+                                                  0.80f, 0.15f, 0.20f); // Red border
+            case PROP_GUN:              return cs(0.18f, 0.18f, 0.18f,  // Black prop body
+                                                  0.65f, 0.60f, 0.55f); // Silver barrel
+
             default:             return c(0.5f, 0.5f, 0.5f);
         }
     }
@@ -7403,6 +7451,11 @@ public enum Material {
             // Issue #1351: Northfield QuickFix Loans — not block items
             case FINAL_DEMAND_LETTER:
             case FORGED_ID:
+            // Issue #1353: Northfield Amateur Dramatics Society — not block items
+            case STAGE_COSTUME:
+            case REHEARSAL_SCHEDULE:
+            case FORGED_TICKET:
+            case PROP_GUN:
             // Issue #1144: Northfield Probation Office — not block items
             case SIGN_ON_LETTER:
             case ELECTRONIC_TAG:
@@ -7657,6 +7710,11 @@ public enum Material {
             // Issue #1351: Northfield QuickFix Loans
             case FINAL_DEMAND_LETTER:
             case FORGED_ID:
+            // Issue #1353: Northfield Amateur Dramatics Society — small items sit on surfaces
+            case STAGE_COSTUME:
+            case REHEARSAL_SCHEDULE:
+            case FORGED_TICKET:
+            case PROP_GUN:
                 return true;
             default:
                 return false;
@@ -8964,6 +9022,16 @@ public enum Material {
                 return IconShape.CYLINDER;    // cloth wristband
             case CHRISTMAS_LIGHTS_BULB:
                 return IconShape.CYLINDER;    // small bulb
+
+            // Issue #1353: Northfield Amateur Dramatics Society
+            case STAGE_COSTUME:
+                return IconShape.BOX;         // folded theatrical costume
+            case REHEARSAL_SCHEDULE:
+                return IconShape.FLAT_PAPER;  // printed timetable sheet
+            case FORGED_TICKET:
+                return IconShape.FLAT_PAPER;  // home-printed ticket
+            case PROP_GUN:
+                return IconShape.BOX;         // stage prop revolver
 
             default:
                 return IconShape.BOX;

--- a/src/main/java/ragamuffin/core/CriminalRecord.java
+++ b/src/main/java/ragamuffin/core/CriminalRecord.java
@@ -1060,7 +1060,30 @@ public class CriminalRecord {
          * Penalty: WantedSystem +1 star, debt written off.
          * Cross-references CRIMINAL_DAMAGE if player also damages property.
          */
-        BAILIFF_ASSAULT("Assault of a court bailiff");
+        BAILIFF_ASSAULT("Assault of a court bailiff"),
+
+        // ── Issue #1353: Northfield Amateur Dramatics Society ─────────────────
+
+        /**
+         * Recorded when the player steals STAGE_COSTUME items from the
+         * COSTUME_CUPBOARD_PROP at the community centre. Penalty: Notoriety +3,
+         * WantedSystem +1 star.
+         */
+        COSTUME_THEFT("Costume theft (NAODS community centre)"),
+
+        /**
+         * Recorded when the player presents a FORGED_TICKET at the TICKET_BOOTH_PROP
+         * and is caught (30% chance). Penalty: Notoriety +2, WantedSystem +1 star.
+         */
+        TICKET_FRAUD("Ticket fraud (forged NAODS opening night ticket)"),
+
+        /**
+         * Recorded when the player executes any of Mario's sabotage options on opening
+         * night: cutting power at FUSE_BOX_PROP, swapping PROP_GUN with AIRGUN, or
+         * stealing TICKET_CASH_BOX_PROP. Penalty: Notoriety +5, WantedSystem +1 star.
+         * Triggers NAODS_DRAMA_DISASTER rumour.
+         */
+        PRODUCTION_SABOTAGE("Production sabotage (NAODS opening night)");
 
         private final String displayName;
 

--- a/src/main/java/ragamuffin/core/RumourType.java
+++ b/src/main/java/ragamuffin/core/RumourType.java
@@ -1039,5 +1039,27 @@ public enum RumourType {
      * full with stolen goods. Didn't seem to bother him." — seeded by
      * PaydayLoanSystem when loan repaid with fenced goods.
      * Spreads via BARMAN and PUBLIC NPCs. */
-    LOAN_SHARK;
+    LOAN_SHARK,
+
+    // ── Issue #1353: Northfield Amateur Dramatics Society ─────────────────────
+
+    /** "There was an absolute disaster at the drama do — power cut, prop gun mix-up,
+     * cash box gone. The whole thing fell apart." — seeded by AmateurDramaticsSystem
+     * when any of Mario's sabotage options are executed on opening night.
+     * Triggers NeighbourhoodSystem Vibes −4 town-wide. Spreads via PUBLIC, BARMAN,
+     * and PENSIONER NPCs. Leads to NewspaperSystem headline next day. */
+    NAODS_DRAMA_DISASTER,
+
+    /** "Someone was listening in at drama rehearsal — reckon they got something on
+     * Marchetti." — seeded by AmateurDramaticsSystem when player eavesdrops on
+     * Mario during his 21:15–21:20 notes break.
+     * Grants MARCHETTI_CREW −5 Respect (surveillance detected). Spreads via
+     * BARMAN and STREET_LAD NPCs as faction intel. */
+    MARCHETTI_SECRETS,
+
+    /** "Patricia's had a load of people auditioning for the drama group — Blood Brothers
+     * apparently." — seeded by AmateurDramaticsSystem when player completes the
+     * audition BattleBarMiniGame (any score ≥ 1).
+     * Spreads via PUBLIC and PENSIONER NPCs. */
+    NAODS_CASTING;
 }

--- a/src/main/java/ragamuffin/entity/NPCType.java
+++ b/src/main/java/ragamuffin/entity/NPCType.java
@@ -2786,7 +2786,38 @@ public enum NPCType {
      * day 4 of non-repayment. Marchetti Crew FRIENDLY respect doubles loan cap to 80 COIN.
      * HP: 30f, attack: 0f, cooldown: 0f, hostile: false.
      */
-    LOAN_SHARK_CLERK(30f, 0f, 0f, false);
+    LOAN_SHARK_CLERK(30f, 0f, 0f, false),
+
+    // ── Issue #1353: Northfield Amateur Dramatics Society ─────────────────────
+
+    /**
+     * DRAMA_DIRECTOR — Patricia, director of the Northfield Amateur Dramatics Society
+     * (NAODS). Oversees rehearsals at the community centre on Wednesdays and Thursdays
+     * 19:00–22:00, and the public production on the last Saturday of the month.
+     * OBSERVANT: 80% catch rate for pickpocketing during rehearsals. Present at
+     * the GP Surgery on Tuesday 13:00–17:00 (opening the costume heist window).
+     * HP: 30f, attack: 0f, cooldown: 0f, hostile: false.
+     */
+    DRAMA_DIRECTOR(30f, 0f, 0f, false),
+
+    /**
+     * NAODS_LEAD_ACTOR — Mario, a Marchetti lieutenant moonlighting as lead actor
+     * in the NAODS production of Blood Brothers. Takes a notes break 21:15–21:20
+     * during rehearsal nights — eavesdropping on him during this window seeds the
+     * MARCHETTI_SECRETS rumour (faction intel). Accepts sabotage contract for 15 COIN
+     * if player has MARCHETTI Respect ≥ 20.
+     * HP: 35f, attack: 5f, cooldown: 1.5f, hostile: false.
+     */
+    NAODS_LEAD_ACTOR(35f, 5f, 1.5f, false),
+
+    /**
+     * NAODS_MEMBER — a rank-and-file member of the Northfield Amateur Dramatics
+     * Society. Attends rehearsals and the public production. Can spot non-cast
+     * wearers of STAGE_COSTUME with a 40% chance, triggering a confrontation.
+     * 8–12 members attend each rehearsal — prime pickpocket opportunity.
+     * HP: 20f, attack: 0f, cooldown: 0f, hostile: false.
+     */
+    NAODS_MEMBER(20f, 0f, 0f, false);
 
     private final float maxHealth;
     private final float attackDamage;   // Damage per hit to player

--- a/src/main/java/ragamuffin/ui/AchievementType.java
+++ b/src/main/java/ragamuffin/ui/AchievementType.java
@@ -5717,6 +5717,42 @@ public enum AchievementType {
         "Last Post",
         "You bought a poppy off Doris and wore it with something approaching dignity.",
         1
+    ),
+
+    // ── Issue #1353: Northfield Amateur Dramatics Society ─────────────────────
+
+    /**
+     * Fires when the player scores 2+ on the BattleBarMiniGame audition and is
+     * cast as Lead Understudy in the NAODS production of Blood Brothers.
+     * Awarded in AmateurDramaticsSystem on audition completion.
+     */
+    BREAK_A_LEG(
+        "Break a Leg",
+        "Lead Understudy in Blood Brothers. Patricia's exact words were 'passable'.",
+        1
+    ),
+
+    /**
+     * Fires when the player successfully executes the costume heist — lockpicking
+     * the COSTUME_CUPBOARD_PROP during the Tuesday 13:00–17:00 window while Patricia
+     * is at the GP Surgery and taking 3–5 STAGE_COSTUMEs.
+     * Awarded in AmateurDramaticsSystem on heist completion.
+     */
+    BEST_IN_SHOW(
+        "Best in Show",
+        "You robbed the drama group's costume cupboard. Curtain up.",
+        1
+    ),
+
+    /**
+     * Fires when the player freezes during the BattleBarMiniGame on stage — scoring
+     * 0 on the opening night performance, causing boos and losing 1 SOCIAL XP.
+     * Awarded in AmateurDramaticsSystem on opening night disaster performance.
+     */
+    STAGE_FRIGHT(
+        "Stage Fright",
+        "You forgot your lines. In front of everyone. There were boos.",
+        1
     );
 
     private final String name;

--- a/src/main/java/ragamuffin/world/PropType.java
+++ b/src/main/java/ragamuffin/world/PropType.java
@@ -3455,7 +3455,59 @@ public enum PropType {
      * Despawns naturally at 23:59 on Remembrance Sunday.
      * Drops POPPY (×3–5) when destroyed.
      */
-    WREATH_PROP(0.60f, 0.30f, 0.60f, 3, Material.POPPY);
+    WREATH_PROP(0.60f, 0.30f, 0.60f, 3, Material.POPPY),
+
+    // ── Issue #1353: Northfield Amateur Dramatics Society ─────────────────────
+
+    /**
+     * AUDITION_NOTICE_PROP — a paper notice pinned on the community centre noticeboard
+     * advertising open auditions for the NAODS production of Blood Brothers. Pressing E
+     * on Tuesdays triggers the BattleBarMiniGame audition sequence (3 cues). Available
+     * every Tuesday until the last Saturday production of the month.
+     * Indestructible (pinned notice).
+     */
+    AUDITION_NOTICE_PROP(0.50f, 0.40f, 0.02f, Integer.MAX_VALUE, null),
+
+    /**
+     * STAGE_MARK_PROP — a taped X on the community centre stage floor marking actor
+     * positions during Blood Brothers rehearsals. Pressing E while standing on one
+     * grants STEALTH XP (stage presence). 8–12 marks placed during rehearsal setup.
+     * Indestructible (tape on floor).
+     */
+    STAGE_MARK_PROP(0.40f, 0.05f, 0.40f, Integer.MAX_VALUE, null),
+
+    /**
+     * COSTUME_CUPBOARD_PROP — a tall wooden wardrobe in the community centre back room
+     * storing 3–5 STAGE_COSTUME items. Lockpickable (requires LOCKPICK) during the
+     * Tuesday 13:00–17:00 heist window while Patricia is at the GP Surgery.
+     * Awards BEST_IN_SHOW achievement on successful heist.
+     * Drops STAGE_COSTUME on destroy.
+     */
+    COSTUME_CUPBOARD_PROP(0.80f, 1.80f, 0.50f, 8, Material.STAGE_COSTUME),
+
+    /**
+     * TICKET_BOOTH_PROP — a small wooden booth at the community centre entrance where
+     * NAODS members sell opening night tickets (2 COIN each, 20 total). Player can
+     * attempt to tout (resell at 4 COIN, risk enforcement) or present forged tickets
+     * (30% caught). Present on the last Saturday of the month from 18:30.
+     * Indestructible (built-in booth).
+     */
+    TICKET_BOOTH_PROP(0.80f, 1.20f, 0.80f, Integer.MAX_VALUE, null),
+
+    /**
+     * TICKET_CASH_BOX_PROP — a metal cash box behind the TICKET_BOOTH_PROP containing
+     * 40 COIN from ticket sales. Stealable as part of Mario's sabotage options.
+     * 6 hits to break open; drops COIN if destroyed.
+     */
+    TICKET_CASH_BOX_PROP(0.30f, 0.20f, 0.20f, 6, Material.COIN),
+
+    /**
+     * PROP_GUN_PROP — a locked cabinet on the community centre stage storing the
+     * PROP_GUN used in the Blood Brothers production. Can be unlocked (press E) or
+     * smashed open (6 hits). Mario's sabotage option: swap PROP_GUN with AIRGUN.
+     * Drops PROP_GUN on destroy.
+     */
+    PROP_GUN_PROP(0.50f, 0.80f, 0.30f, 6, Material.PROP_GUN);
 
     // ─────────────────────────────────────────────────────────────────────────
     // Issue #719: Collision and destructibility data


### PR DESCRIPTION
## Summary
Automated fix for issue #1353.

## Changes
- Fix #1353: automated fix

Closes #1353