### PR TITLE
Fix #1361: Add Northfield St. Margaret's Church Hall Jumble Sale — The Early Bird, the Mystery Box & the Vicar's Blind Eye

### DIFF
--- a/src/main/java/ragamuffin/building/Material.java
+++ b/src/main/java/ragamuffin/building/Material.java
@@ -5781,7 +5781,49 @@ public enum Material {
      * Crafted from COIN (10) + BROWN_ENVELOPE (already in inventory if available).
      * Tooltip: "A discreet envelope. Best offered quietly."
      */
-    CASH_BRIBE_ENVELOPE("Cash Bribe Envelope");
+    CASH_BRIBE_ENVELOPE("Cash Bribe Envelope"),
+
+    // ── Issue #1361: Northfield St. Margaret's Church Hall Jumble Sale ─────────
+
+    /**
+     * JAM_JAR — Margaret's homemade jam sold at St. Margaret's jumble sale till.
+     * Costs 2 COIN. Consuming restores 20 hunger. Can be thrown at a PENSIONER
+     * crowd as a distraction, causing STARTLED state and a 15-second unattended
+     * stall window. Stealing without paying: PETTY_THEFT + Margaret HOSTILE.
+     * Tooltip: "Homemade jam. Goes well on toast. Or as a projectile."
+     */
+    JAM_JAR("Homemade Jam"),
+
+    /**
+     * MYSTERY_BOX — sealed auction container used in the noon Mystery Box Auction
+     * at St. Margaret's. Three spawn at 11:00 near Reverend Dave. Contains random
+     * loot: junk / useful / SCORE tier (DIAMOND, WAR_MEDAL, STOLEN_PHONE).
+     * Cannot be sold before opening; opens on auction win.
+     */
+    MYSTERY_BOX("Mystery Box"),
+
+    /**
+     * BAIT_ITEM — planted inside a MYSTERY_BOX_PROP before 11:00 using a STEALTH
+     * approach (requires Notoriety < 30) to inflate NPC bids on that box by ×1.5,
+     * driving it out of NPC budget and letting the player win the other cheaply.
+     * Tooltip: "Looks tempting. That's the point."
+     */
+    BAIT_ITEM("Planted Bait"),
+
+    /**
+     * VALUABLE_DONATION — high-value item skimmed from donation bags during the
+     * volunteer sort shift (08:00–09:00). Worth 3× normal fence value. If Reverend
+     * Dave catches the player pocketing one (15% risk): CAUGHT_NICKING_DONATIONS
+     * crime + Notoriety +8 + 7-day volunteer ban.
+     */
+    VALUABLE_DONATION("Valuable Donation"),
+
+    /**
+     * JUMBLE_FIND — random low-value item yielded from sorting donation bags during
+     * the volunteer shift. 40% chance per sort action. No crime risk; honest perk
+     * of volunteering.
+     */
+    JUMBLE_FIND("Jumble Find");
 
     private final String displayName;
 

--- a/src/main/java/ragamuffin/entity/NPCType.java
+++ b/src/main/java/ragamuffin/entity/NPCType.java
@@ -2850,7 +2850,26 @@ public enum NPCType {
      * raid at 06:30), Derek arrives with 2× HMRC_INSPECTOR + enforcement officer.
      * HP: 40f, attack: 5f, cooldown: 1.5f, hostile: false (becomes hostile only on assault).
      */
-    DISTRAINT_OFFICER(40f, 5f, 1.5f, false);
+    DISTRAINT_OFFICER(40f, 5f, 1.5f, false),
+
+    // ── Issue #1361: Northfield St. Margaret's Church Hall Jumble Sale ─────────
+
+    /**
+     * VICAR — Reverend Dave, the cheerfully incompetent auctioneer and donation
+     * drop-off manager at St. Margaret's Church Hall. Runs the donation volunteer
+     * shift 08:00–09:00 and the Mystery Box auction at 12:00. Passive (never
+     * attacks). Can be bribed with 5 COIN to reveal the SCORE mystery box.
+     * HP: 20f, attack: 0f, cooldown: 0f, hostile: false.
+     */
+    VICAR(20f, 0f, 0f, false),
+
+    /**
+     * CHURCH_LADY — one of two till operators at St. Margaret's Church Hall jumble
+     * sale. Acts as an unwitting fence intermediary; buys items at 60% fence value
+     * (no questions asked, up to 3 items per session). Seeds COMMUNITY_WIN rumours.
+     * HP: 15f, attack: 0f, cooldown: 0f, hostile: false.
+     */
+    CHURCH_LADY(15f, 0f, 0f, false);
 
     private final float maxHealth;
     private final float attackDamage;   // Damage per hit to player

--- a/src/main/java/ragamuffin/world/PropType.java
+++ b/src/main/java/ragamuffin/world/PropType.java
@@ -3552,7 +3552,35 @@ public enum PropType {
      * DAWN_RAID_SURVIVOR achievement. Destructible by player (hitsToBreak: 2, GLASS).
      * Drops GLASS on destroy.
      */
-    BACK_WINDOW_PROP(0.80f, 1.00f, 0.10f, 2, Material.GLASS);
+    BACK_WINDOW_PROP(0.80f, 1.00f, 0.10f, 2, Material.GLASS),
+
+    // ── Issue #1361: Northfield St. Margaret's Church Hall Jumble Sale ─────────
+
+    /**
+     * JUMBLE_TABLE_PROP — a long trestle table laden with bric-a-brac.
+     * Present in St. Margaret's Church Hall from 08:00 Saturday. Interactable
+     * for browsing (press E). First player/NPC to reach one within 5 s of 09:00
+     * opening gets the EARLY_BIRD 30% discount. Indestructible (hitsToBreak: 999).
+     * Drops nothing.
+     */
+    JUMBLE_TABLE_PROP(2.00f, 0.90f, 0.60f, 999, null),
+
+    /**
+     * DONATION_BOX_PROP — the donation intake point managed by Reverend Dave during
+     * 08:00–09:00. Press E to donate items or start a volunteer sort shift. Items
+     * donated here appear in the charity shop stock next Monday. Indestructible.
+     * Drops nothing.
+     */
+    DONATION_BOX_PROP(0.80f, 1.00f, 0.80f, 999, null),
+
+    /**
+     * MYSTERY_BOX_PROP — one of three sealed auction boxes spawned near Reverend Dave
+     * at 11:00. Contains random loot (junk/useful/SCORE tier). Player can plant a
+     * BAIT_ITEM before 11:00. Revealed and distributed at 12:00 auction. Indestructible
+     * by normal means (hitsToBreak: 999). Drops its contained MYSTERY_BOX material on
+     * auction win.
+     */
+    MYSTERY_BOX_PROP(0.60f, 0.60f, 0.60f, 999, Material.MYSTERY_BOX);
 
     // ─────────────────────────────────────────────────────────────────────────
     // Issue #719: Collision and destructibility data


### PR DESCRIPTION
## Summary
Automated fix for issue #1361.

## Changes
- Fix #1361: automated fix

Closes #1361