### PR TITLE
Fix #1371: Add Northfield Christmas Market — The Pop-Up Stalls, the Carol Singers & the Counterfeit Goods Sting

### DIFF
--- a/src/main/java/ragamuffin/audio/SoundEffect.java
+++ b/src/main/java/ragamuffin/audio/SoundEffect.java
@@ -50,5 +50,8 @@ public enum SoundEffect {
 
     // Issue #1369: Northfield New Year's Eve
     FIREWORK_BANG,  // Firework rocket detonation at midnight on NYE
-    NYE_CROWD_CHEER  // Crowd cheering at midnight on NYE (distinct from football cheer)
+    NYE_CROWD_CHEER,  // Crowd cheering at midnight on NYE (distinct from football cheer)
+
+    // Issue #1371: Northfield Christmas Market
+    CAROL_SINGING  // Ambient carol singing from CAROL_SINGER NPCs at the CAROL_SONG_BOARD_PROP
 }

--- a/src/main/java/ragamuffin/building/Material.java
+++ b/src/main/java/ragamuffin/building/Material.java
@@ -5891,7 +5891,37 @@ public enum Material {
     /** Small purse dropped by Sharon (DRUNK NPC) near the park entrance on NYE.
      * Contains 4–8 COIN. Returning to Sharon: Respect +3, HONEST_FINDER achievement.
      * Keeping it: THEFT_FROM_PERSON CriminalRecord, Notoriety +4. */
-    PURSE("Purse");
+    PURSE("Purse"),
+
+    // ── Issue #1371: Northfield Christmas Market ──────────────────────────────
+
+    /** Grilled bratwurst sausage sold by Dietmar at the Christmas Market.
+     * Consuming heals +10 HP. Available 10:00–20:00 on market days (335–356). */
+    BRATWURST("Bratwurst"),
+
+    /** Small festive trinket (novelty decoration, snow globe, etc.) sold by Linda.
+     * Giving one to a PENSIONER NPC: Community Respect +2. */
+    CHRISTMAS_TRINKET("Christmas Trinket"),
+
+    /** Traditional candy cane; sold at various stalls and in Santa's Grotto.
+     * Small sugar rush (+2 HP, minor energy boost). */
+    CANDY_CANE("Candy Cane"),
+
+    /** Numbered paper raffle ticket sold by Margaret at the charity stall.
+     * Resolved at 19:30; 10% chance of winning a CHRISTMAS_HAMPER. */
+    RAFFLE_TICKET("Raffle Ticket"),
+
+    /** Wicker hamper filled with festive goods — the raffle jackpot prize.
+     * High barter value; sellable to FENCE for 12 COIN. */
+    CHRISTMAS_HAMPER("Christmas Hamper"),
+
+    /** Counterfeit designer scarf sold by Colin (DODGY_TRADER).
+     * Triggers Trading Standards mechanic when in inventory during Janet's inspection. */
+    FAKE_DESIGNER_SCARF("Fake Designer Scarf"),
+
+    /** Clip-on "I'M SANTA" badge pickpocketed from Terry in costume.
+     * Unlocks MUGGED_FATHER_CHRISTMAS achievement. Tradeable novelty item. */
+    SANTA_BADGE("Santa Badge");
 
     private final String displayName;
 
@@ -9259,6 +9289,22 @@ public enum Material {
             // Issue #1367: Northfield Speed Awareness Course
             case SPEEDING_NOTICE:
                 return IconShape.FLAT_PAPER;  // Section 172 NIP letter
+
+            // Issue #1371: Northfield Christmas Market
+            case BRATWURST:
+                return IconShape.CYLINDER;    // grilled sausage in a bun
+            case CHRISTMAS_TRINKET:
+                return IconShape.BOX;         // small festive knick-knack
+            case CANDY_CANE:
+                return IconShape.CYLINDER;    // striped sugar cane
+            case RAFFLE_TICKET:
+                return IconShape.FLAT_PAPER;  // numbered paper strip
+            case CHRISTMAS_HAMPER:
+                return IconShape.BOX;         // wicker hamper with ribbon
+            case FAKE_DESIGNER_SCARF:
+                return IconShape.BOX;         // folded counterfeit scarf
+            case SANTA_BADGE:
+                return IconShape.FLAT_PAPER;  // clip-on "I'M SANTA" badge
 
             default:
                 return IconShape.BOX;

--- a/src/main/java/ragamuffin/core/RumourType.java
+++ b/src/main/java/ragamuffin/core/RumourType.java
@@ -1115,5 +1115,21 @@ public enum RumourType {
     /** "Absolute carnage out there last night. Police everywhere."
      * Seeded at midnight on day 1 (after NYE). Spreads via PUBLIC, DRUNK.
      * Spread velocity +3. */
-    NYE_CHAOS;
+    NYE_CHAOS,
+
+    // ── Issue #1371: Northfield Christmas Market ──────────────────────────────
+
+    /** "The Christmas Market's on down by the war memorial — mulled wine,
+     * bratwurst, the lot. It's actually quite nice this year."
+     * Seeded by ChristmasMarketSystem when market opens (10:00, days 335–356).
+     * Triggers NeighbourhoodSystem Vibes +3/hr while active.
+     * Spreads via PUBLIC, PENSIONER, and SCHOOL_KID NPCs. */
+    CHRISTMAS_CHEER,
+
+    /** "The Christmas Market's been cancelled — bucketing it down, no vendors
+     * bothered showing up."
+     * Seeded by ChristmasMarketSystem when HEAVY_RAIN or THUNDERSTORM cancels
+     * the market. Triggers NeighbourhoodSystem Vibes −2.
+     * Spreads via PUBLIC and PENSIONER NPCs. */
+    XMAS_MARKET_CANCELLED;
 }

--- a/src/main/java/ragamuffin/entity/NPCType.java
+++ b/src/main/java/ragamuffin/entity/NPCType.java
@@ -2928,7 +2928,33 @@ public enum NPCType {
      * reacts angrily if the display is sabotaged. Non-hostile.
      * HP: 20f, attack: 0f, cooldown: 0f, hostile: false.
      */
-    EVENT_COMPERE(20f, 0f, 0f, false);
+    EVENT_COMPERE(20f, 0f, 0f, false),
+
+    // ── Issue #1371: Northfield Christmas Market ──────────────────────────────
+
+    /**
+     * SANTA_CLAUS — Terry in full Father Christmas costume manning Santa's Grotto.
+     * Non-hostile (it's Christmas). Pickpocketable for SANTA_BADGE.
+     * Becomes distracted when grotto queue ≥ 3 (enabling GROTTO_TIN theft).
+     * HP: 30f, attack: 0f, cooldown: 0f, hostile: false.
+     */
+    SANTA_CLAUS(30f, 0f, 0f, false),
+
+    /**
+     * CAROL_SINGER — one of 3–5 volunteer carol singers performing at the
+     * CAROL_SONG_BOARD_PROP 17:00–19:00. Pickpocketable (SLEIGHT_OF_HAND).
+     * Flees on firework disruption. Non-hostile.
+     * HP: 20f, attack: 0f, cooldown: 0f, hostile: false.
+     */
+    CAROL_SINGER(20f, 0f, 0f, false),
+
+    /**
+     * XMAS_STALL_VENDOR — generic Christmas market stall vendor (Carol, Dietmar,
+     * Linda, Margaret). Non-hostile traders who staff their XMAS_MARKET_CHALET_PROP
+     * during market hours 10:00–20:00.
+     * HP: 25f, attack: 0f, cooldown: 0f, hostile: false.
+     */
+    XMAS_STALL_VENDOR(25f, 0f, 0f, false);
 
     private final float maxHealth;
     private final float attackDamage;   // Damage per hit to player

--- a/src/main/java/ragamuffin/ui/AchievementType.java
+++ b/src/main/java/ragamuffin/ui/AchievementType.java
@@ -5950,6 +5950,79 @@ public enum AchievementType {
         "Honest Finder",
         "You found her purse and gave it back. Northfield noticed.",
         1
+    ),
+
+    // ── Issue #1371: Northfield Christmas Market ──────────────────────────────
+
+    /**
+     * Awarded when the player steals the GROTTO_TIN from Santa's Grotto while
+     * Terry is distracted by a queue of ≥ 3 SCHOOL_KID NPCs. Notoriety +10.
+     */
+    CHRISTMAS_VILLAIN(
+        "Christmas Villain",
+        "You robbed Santa's collection tin. Northfield will never forgive you.",
+        1
+    ),
+
+    /**
+     * Awarded when the player returns the GROTTO_TIN within 30 in-game minutes
+     * of stealing it, reversing the theft and redeeming themselves.
+     */
+    CHRISTMAS_REDEMPTION(
+        "Christmas Redemption",
+        "You put the tin back. Christmas is saved. Probably.",
+        1
+    ),
+
+    /**
+     * Awarded when the player pickpockets SANTA_BADGE from Terry while he is in
+     * his SANTA_CLAUS costume at the grotto.
+     */
+    MUGGED_FATHER_CHRISTMAS(
+        "Mugged Father Christmas",
+        "You nicked Santa's badge. That's a new low, even for you.",
+        1
+    ),
+
+    /**
+     * Awarded when the player disrupts the carol singers with a firework and all
+     * CAROL_SINGER NPCs flee. Notoriety +8 and WantedSystem +1.
+     */
+    CAROL_CRASHER(
+        "Carol Crasher",
+        "You scared off the carol singers. Bah humbug.",
+        1
+    ),
+
+    /**
+     * Awarded when the player is caught attempting to rig the charity raffle drum
+     * (FENCE skill ≥ Journeyman) while Margaret is watching. Records FRAUD crime.
+     */
+    CHARITY_CROOK(
+        "Charity Crook",
+        "Caught rigging the raffle. Margaret will never let this go.",
+        1
+    ),
+
+    /**
+     * Awarded when the player successfully rigs the RAFFLE_TICKET_DRUM_PROP while
+     * Margaret is distracted, guaranteeing the CHRISTMAS_HAMPER jackpot.
+     */
+    RIGGED_IT(
+        "Rigged It",
+        "The hamper was always yours. Margaret suspects nothing.",
+        1
+    ),
+
+    /**
+     * Awarded when the player tips off Janet (TRADING_STANDARDS_OFFICER) with
+     * evidence of Colin's FAKE_DESIGNER_SCARF operation, getting him ejected.
+     * Notoriety −4, Community Respect bonus.
+     */
+    COMMUNITY_CHAMPION(
+        "Community Champion",
+        "You grassed up Colin's dodgy scarf stall. Northfield thanks you.",
+        1
     );
 
     private final String name;

--- a/src/main/java/ragamuffin/world/PropType.java
+++ b/src/main/java/ragamuffin/world/PropType.java
@@ -3657,7 +3657,43 @@ public enum PropType {
      * home after the NYE lock-in. 3.0×3.0×3.0m; indestructible. Player must walk
      * within 5 blocks to complete the "help home" interaction.
      */
-    LANDLORD_HOUSE_PROP(3.0f, 3.0f, 3.0f, 999, null);
+    LANDLORD_HOUSE_PROP(3.0f, 3.0f, 3.0f, 999, null),
+
+    // ── Issue #1371: Northfield Christmas Market ──────────────────────────────
+
+    /**
+     * XMAS_MARKET_CHALET_PROP — a wooden market chalet (stall booth) used by
+     * all six Christmas Market vendors near the war memorial. 2.0×2.5×1.5m;
+     * indestructible during event. Drops WOOD when broken after event ends.
+     */
+    XMAS_MARKET_CHALET_PROP(2.0f, 2.5f, 1.5f, 999, Material.WOOD),
+
+    /**
+     * SANTA_GROTTO_PROP — a decorated grotto booth where SANTA_CLAUS (Terry)
+     * receives SCHOOL_KID visitors. Hosts the GROTTO_TIN. 3.0×3.0×2.0m;
+     * indestructible during event.
+     */
+    SANTA_GROTTO_PROP(3.0f, 3.0f, 2.0f, 999, null),
+
+    /**
+     * CAROL_SONG_BOARD_PROP — a board with printed carol lyrics where
+     * CAROL_SINGER NPCs gather 17:00–19:00. 0.5×1.5×0.1m; fragile.
+     */
+    CAROL_SONG_BOARD_PROP(0.5f, 1.5f, 0.1f, 3, null),
+
+    /**
+     * RAFFLE_TICKET_DRUM_PROP — Margaret's charity raffle drum. Can be swapped
+     * by the player (FENCE ≥ Journeyman) to guarantee winning ticket.
+     * 0.6×0.8×0.6m; moderate durability.
+     */
+    RAFFLE_TICKET_DRUM_PROP(0.6f, 0.8f, 0.6f, 5, null),
+
+    /**
+     * GROTTO_TIN — the collection tin placed inside Santa's Grotto that
+     * accumulates 1 COIN per SCHOOL_KID visitor (max 20/day). Stealable when
+     * Terry is distracted. 0.2×0.3×0.2m; fragile.
+     */
+    GROTTO_TIN(0.2f, 0.3f, 0.2f, 2, Material.COIN);
 
     // ─────────────────────────────────────────────────────────────────────────
     // Issue #719: Collision and destructibility data


### PR DESCRIPTION
## Summary
Automated fix for issue #1371.

## Changes
- Fix #1371: automated fix

Closes #1371