### PR TITLE
Fix #1383: Add Northfield Boxing Day Sales — The 6am Iceland Scrum, the Scalper's Hustle & the CCTV Blackout

### DIFF
--- a/src/main/java/ragamuffin/building/Material.java
+++ b/src/main/java/ragamuffin/building/Material.java
@@ -6015,7 +6015,50 @@ public enum Material {
     POINTY_HAT("Pointy Hat"),
 
     /** Wearable costume accessory — part of the witch/vampire costume set. */
-    BLACK_CAPE("Black Cape");
+    BLACK_CAPE("Black Cape"),
+
+    // ── Issue #1383: Northfield Boxing Day Sales ──────────────────────────────
+
+    /**
+     * Frozen Prawn Ring — "A ring of frozen prawns. A Boxing Day staple."
+     * Iceland sale item; 50% off during rush window (06:00–07:30). */
+    FROZEN_PRAWN_RING("Frozen Prawn Ring"),
+
+    /**
+     * Party Food Platter — "Assorted party snacks on a plastic tray."
+     * Iceland sale item; 50% off during rush window. */
+    PARTY_FOOD_PLATTER("Party Food Platter"),
+
+    /**
+     * Luxury Biscuit Tin — "A large tin of assorted biscuits. Someone will eat all the nice ones first."
+     * Iceland sale item, limited stock (8 units); scalped by Wayne outside. */
+    LUXURY_BISCUIT_TIN("Luxury Biscuit Tin"),
+
+    /**
+     * George Foreman Grill — "The one everyone wants. There's only one left."
+     * Iceland sale item, strictly 1 unit; triggers SALE_DISPUTE fight if two NPCs reach it.
+     * Wayne scalps it for 15 COIN. Selling one to queue NPCs for 14 COIN awards SALE_SHARK. */
+    GEORGE_FOREMAN_GRILL("George Foreman Grill"),
+
+    /**
+     * Bread Maker — "Not what anyone queued for. Still, it's something."
+     * Charity shop Boxing Day stock; actually useful — flip at PawnShop for 2 COIN. */
+    BREAD_MAKER("Bread Maker"),
+
+    /**
+     * Vinyl Record Box — "A cardboard box of mixed records. Mostly rubbish."
+     * Charity shop Boxing Day stock; 5% chance contains a GENUINE_FIRST_PRESSING. */
+    VINYL_RECORD_BOX("Vinyl Record Box"),
+
+    /**
+     * Genuine First Pressing — "Rare. 8 COIN at PawnShop. Brenda has no idea."
+     * Hidden inside VINYL_RECORD_BOX (5% chance). Awards CHARITY_SHOP_TREASURE. */
+    GENUINE_FIRST_PRESSING("Genuine First Pressing"),
+
+    /**
+     * HDMI Cable — "Found near the DVR. Suspiciously tangled."
+     * Looted near Iceland DVR; connection to the CCTV Blackout incident. */
+    HDMI_CABLE("HDMI Cable");
 
     private final String displayName;
 
@@ -7345,6 +7388,21 @@ public enum Material {
             case POINTY_HAT:        return c(0.10f, 0.08f, 0.12f); // Black witch hat
             case BLACK_CAPE:        return c(0.08f, 0.08f, 0.10f); // Deep black cape
 
+            // Issue #1383: Northfield Boxing Day Sales
+            case FROZEN_PRAWN_RING:      return c(0.88f, 0.62f, 0.55f); // Pale pink/peach
+            case PARTY_FOOD_PLATTER:     return cs(0.92f, 0.88f, 0.78f, // Cream platter
+                                                   0.88f, 0.22f, 0.18f); // Red food items
+            case LUXURY_BISCUIT_TIN:     return cs(0.72f, 0.12f, 0.12f, // Deep red tin
+                                                   0.85f, 0.72f, 0.10f); // Gold embossing
+            case GEORGE_FOREMAN_GRILL:   return cs(0.20f, 0.22f, 0.25f, // Dark grey grill body
+                                                   0.65f, 0.65f, 0.68f); // Silver grill plate
+            case BREAD_MAKER:            return c(0.72f, 0.70f, 0.65f);  // Off-white plastic
+            case VINYL_RECORD_BOX:       return cs(0.75f, 0.62f, 0.38f, // Brown cardboard
+                                                   0.10f, 0.10f, 0.10f); // Black record peek
+            case GENUINE_FIRST_PRESSING: return cs(0.10f, 0.10f, 0.10f, // Black vinyl
+                                                   0.82f, 0.72f, 0.10f); // Gold label
+            case HDMI_CABLE:             return c(0.18f, 0.18f, 0.20f);  // Dark grey/black cable
+
             default:             return c(0.5f, 0.5f, 0.5f);
         }
     }
@@ -7906,6 +7964,15 @@ public enum Material {
             case PUMPKIN_INNARDS:
             case POINTY_HAT:
             case BLACK_CAPE:
+            // Issue #1383: Northfield Boxing Day Sales — not block items
+            case FROZEN_PRAWN_RING:
+            case PARTY_FOOD_PLATTER:
+            case LUXURY_BISCUIT_TIN:
+            case GEORGE_FOREMAN_GRILL:
+            case BREAD_MAKER:
+            case VINYL_RECORD_BOX:
+            case GENUINE_FIRST_PRESSING:
+            case HDMI_CABLE:
                 return false;
             default:
                 return true;
@@ -9512,6 +9579,24 @@ public enum Material {
                 return IconShape.BOX;         // pointed hat
             case BLACK_CAPE:
                 return IconShape.FLAT_PAPER;  // folded cape
+
+            // Issue #1383: Northfield Boxing Day Sales
+            case FROZEN_PRAWN_RING:
+                return IconShape.FOOD;        // ring of frozen prawns
+            case PARTY_FOOD_PLATTER:
+                return IconShape.BOX;         // flat plastic platter
+            case LUXURY_BISCUIT_TIN:
+                return IconShape.BOX;         // round biscuit tin
+            case GEORGE_FOREMAN_GRILL:
+                return IconShape.BOX;         // compact electric grill
+            case BREAD_MAKER:
+                return IconShape.BOX;         // boxy kitchen appliance
+            case VINYL_RECORD_BOX:
+                return IconShape.BOX;         // cardboard box of records
+            case GENUINE_FIRST_PRESSING:
+                return IconShape.CYLINDER;    // rare vinyl disc
+            case HDMI_CABLE:
+                return IconShape.TOOL;        // cable / lead shape
 
             default:
                 return IconShape.BOX;

--- a/src/main/java/ragamuffin/ui/AchievementType.java
+++ b/src/main/java/ragamuffin/ui/AchievementType.java
@@ -6179,6 +6179,63 @@ public enum AchievementType {
         "Night Owl",
         "Still out after midnight on Halloween. The estate is yours. Almost.",
         1
+    ),
+
+    // ── Issue #1383: Northfield Boxing Day Sales ──────────────────────────────
+
+    /**
+     * BOXING_DAY_EARLY_BIRD — join the Iceland queue before 06:00 on Boxing Day (target=1).
+     */
+    BOXING_DAY_EARLY_BIRD(
+        "Boxing Day Early Bird",
+        "You queued at 5:30am outside Iceland in December. For a prawn ring. Respect.",
+        1
+    ),
+
+    /**
+     * SALE_SHARK — undersell Wayne by selling a self-acquired GEORGE_FOREMAN_GRILL to
+     * queue NPCs for 14 COIN (target=1).
+     */
+    SALE_SHARK(
+        "Sale Shark",
+        "Undercut Wayne's van operation. He won't forget this.",
+        1
+    ),
+
+    /**
+     * BOXING_DAY_VILLAIN — rob Wayne's van with a CROWBAR during the Boxing Day sale (target=1).
+     */
+    BOXING_DAY_VILLAIN(
+        "Boxing Day Villain",
+        "Robbed Wayne's Boxing Day van. The queue slow-clapped. Mixed reviews.",
+        1
+    ),
+
+    /**
+     * CHARITY_SHOP_TREASURE — pull a GENUINE_FIRST_PRESSING from Brenda's VINYL_RECORD_BOX (target=1).
+     */
+    CHARITY_SHOP_TREASURE(
+        "Charity Shop Treasure",
+        "Found a genuine first pressing in Brenda's record box. She had no idea.",
+        1
+    ),
+
+    /**
+     * SALE_MEDIATOR — step in to resolve a SALE_DISPUTE fight over the GEORGE_FOREMAN_GRILL (target=1).
+     */
+    SALE_MEDIATOR(
+        "Sale Mediator",
+        "Broke up a Boxing Day brawl over a George Foreman Grill. Diplomatically.",
+        1
+    ),
+
+    /**
+     * BLACKOUT_BANDIT — exploit the CCTV blackout window at Iceland on Boxing Day (target=1).
+     */
+    BLACKOUT_BANDIT(
+        "Blackout Bandit",
+        "Took full advantage of the CCTV outage. Sharon tripped over the cable. Timing is everything.",
+        1
     );
 
     private final String name;

--- a/src/main/java/ragamuffin/world/PropType.java
+++ b/src/main/java/ragamuffin/world/PropType.java
@@ -3774,7 +3774,30 @@ public enum PropType {
      * Provides basic rain cover over the trestle tables.
      * 3.0×0.1×2.0m; fragile.
      */
-    TARPAULIN_PROP(3.0f, 0.1f, 2.0f, 2, null);
+    TARPAULIN_PROP(3.0f, 0.1f, 2.0f, 2, null),
+
+    // ── Issue #1383: Northfield Boxing Day Sales ──────────────────────────────
+
+    /**
+     * SALE_QUEUE_BARRIER_PROP — retractable crowd-control barrier outside Iceland.
+     * Spawned at 05:30 on Boxing Day; defines the queue lane.
+     * 1.2×0.9×0.1m; sturdy.
+     */
+    SALE_QUEUE_BARRIER_PROP(1.2f, 0.9f, 0.1f, 8, null),
+
+    /**
+     * WAYNE_VAN_PROP — Wayne's white Transit van parked outside Iceland.
+     * Active 06:30–12:00 on Boxing Day. Player can buy, rob (CROWBAR), or undercut Wayne.
+     * 4.0×2.0×2.0m; very sturdy.
+     */
+    WAYNE_VAN_PROP(4.0f, 2.0f, 2.0f, 20, null),
+
+    /**
+     * SALE_SIGN_PROP — bright red A-board sign: "BOXING DAY SALE — UP TO 50% OFF".
+     * Spawned outside ICELAND, POUND_SHOP, and CHARITY_SHOP at 06:00. Despawns at 18:00.
+     * 0.6×1.2×0.1m; fragile.
+     */
+    SALE_SIGN_PROP(0.6f, 1.2f, 0.1f, 2, null);
 
     // ─────────────────────────────────────────────────────────────────────────
     // Issue #719: Collision and destructibility data


### PR DESCRIPTION
## Summary
Automated fix for issue #1383.

## Changes
- Fix #1383: automated fix

Closes #1383