### PR TITLE
Fix #1390: Add Northfield Annual Conker Championship — The Vinegar Cheat, the String Snap & the Trophy Hustle

### DIFF
--- a/src/main/java/ragamuffin/core/CriminalRecord.java
+++ b/src/main/java/ragamuffin/core/CriminalRecord.java
@@ -1174,7 +1174,17 @@ public class CriminalRecord {
          * Recorded when the player steals MORRIS_STICK_PROP from a MORRIS_DANCER NPC.
          * Penalty: Notoriety +1, WantedSystem +1 star; all 6 dancers pursue.
          */
-        MORRIS_STICK_THEFT("Theft of a Morris dancing prop");
+        MORRIS_STICK_THEFT("Theft of a Morris dancing prop"),
+
+        // ── Issue #1390: Northfield Annual Conker Championship ────────────────
+
+        /**
+         * Recorded when organiser Derek catches the player competing with a
+         * HARDENED_CONKER during the Northfield Annual Conker Championship.
+         * ConkerSystem spot-check: 20% chance per tick. DisguiseSystem blocks check.
+         * Penalty: disqualification, Notoriety +2.
+         */
+        CHEATING_AT_CONKERS("Competing with a hardened/chemically-treated conker");
 
         private final String displayName;
 

--- a/src/main/java/ragamuffin/core/RumourType.java
+++ b/src/main/java/ragamuffin/core/RumourType.java
@@ -1219,5 +1219,23 @@ public enum RumourType {
      * Seeded by StGeorgesDaySystem when player steals MORRIS_STICK_PROP.
      * Triggers all 6 MORRIS_DANCER NPCs to pursue player.
      * Spreads via PUBLIC NPCs. */
-    MORRIS_STICK_THEFT;
+    MORRIS_STICK_THEFT,
+
+    // ── Issue #1390: Northfield Annual Conker Championship ───────────────────
+
+    /** "Someone got disqualified at the conker championship — Derek found a hardened one."
+     * Seeded by ConkerSystem when Derek catches the player with a HARDENED_CONKER.
+     * Triggers Notoriety +2 and CHEATING_AT_CONKERS CriminalRecord entry.
+     * Spreads via PUBLIC, PENSIONER NPCs. */
+    CONKER_CHEAT_CAUGHT,
+
+    /** "Little Tyler won the conker championship! Nine years old and beat the lot of them."
+     * Seeded by ConkerSystem when Tyler wins the tournament (player threw match or lost).
+     * Triggers NewspaperSystem headline. Spreads via PUBLIC, PENSIONER NPCs. */
+    TYLER_WON_IT,
+
+    /** "Someone's nicked the conker trophy off the prize table. Right under Derek's nose."
+     * Seeded by ConkerSystem when player takes CONKER_TROPHY from TROPHY_TABLE_PROP.
+     * Triggers Notoriety +5. Spreads via PUBLIC, PENSIONER NPCs. */
+    CONKER_TROPHY_NICKED;
 }

--- a/src/main/java/ragamuffin/ui/AchievementType.java
+++ b/src/main/java/ragamuffin/ui/AchievementType.java
@@ -6292,6 +6292,48 @@ public enum AchievementType {
         "Lock-In Legend",
         "Made it to 2am in a Wetherspoons lock-in while the police knocked on the door. Respect.",
         1
+    ),
+
+    // ── Issue #1390: Northfield Annual Conker Championship ────────────────────
+
+    /**
+     * INCOGNITO_CONKER — DisguiseSystem blocks Derek's spot-check during the
+     * Northfield Annual Conker Championship (target=1).
+     */
+    INCOGNITO_CONKER(
+        "Incognito Conker",
+        "Passed Derek's spot-check in full disguise. The vinegar smell nearly gave it away.",
+        1
+    ),
+
+    /**
+     * LET_THE_KID_WIN — player deliberately throws the duel against Tyler (age 9),
+     * granting VIBES +2 (target=1).
+     */
+    LET_THE_KID_WIN(
+        "Let the Kid Win",
+        "You could have smashed Tyler's conker. You chose not to. A rare act of mercy.",
+        1
+    ),
+
+    /**
+     * TOOK_THE_LOT — player steals CONKER_TROPHY from TROPHY_TABLE_PROP during the
+     * unattended heist window 15:30–15:45 while Derek is at Margaret's WI stall (target=1).
+     */
+    TOOK_THE_LOT(
+        "Took the Lot",
+        "Nicked the Conker Championship trophy while Derek was eating a jacket potato.",
+        1
+    ),
+
+    /**
+     * NORTHFIELD_CONKER_CHAMPION — player wins the Northfield Annual Conker
+     * Championship outright, receiving trophy + 25 COIN (target=1).
+     */
+    NORTHFIELD_CONKER_CHAMPION(
+        "Northfield Conker Champion",
+        "Won the Annual Conker Championship fair and square. Well, mostly fair.",
+        1
     );
 
     private final String name;


### PR DESCRIPTION
## Summary
Automated fix for issue #1390.

## Changes
- Fix #1390: automated fix

Closes #1390