### PR TITLE
Fix #1400: Add Northfield Residents' Parking Permit Racket — The Zone Sign Fiddle, the Clamping Ambush & the Council Enforcement Bribe

### DIFF
--- a/src/main/java/ragamuffin/building/Material.java
+++ b/src/main/java/ragamuffin/building/Material.java
@@ -6241,7 +6241,31 @@ public enum Material {
     /**
      * TERRY_DEBT_NOTE — "Payment refused. Property: 14 Acacia Ave. Amount: 2 COIN. Date noted."
      * Given to player after reporting a defaulter to Terry. Redeemable for 1 COIN + gossip. */
-    TERRY_DEBT_NOTE("Terry's Debt Note");
+    TERRY_DEBT_NOTE("Terry's Debt Note"),
+
+    // ── Issue #1400: Northfield Residents' Parking Permit Racket ─────────────
+
+    /**
+     * PARKING_PERMIT — "Zone S Residents' Parking Permit. Valid 168 hours. Do not bend."
+     * Sold by Brenda (COUNCIL_CLERK) at the COUNCIL_OFFICE_KIOSK for 4 COIN.
+     * Valid 168 in-game hours; prevents Barry from clamping the player's car. */
+    PARKING_PERMIT("Parking Permit"),
+
+    /**
+     * FORGED_PARKING_PERMIT — "Zone S Residents' Parking Permit. Printed in Comic Sans."
+     * Crafted from STOLEN_PRINTER_INK + CARDBOARD (or at internet café).
+     * 20% detection chance when Barry inspects → CrimeType.DOCUMENT_FRAUD, Notoriety +5. */
+    FORGED_PARKING_PERMIT("Forged Parking Permit"),
+
+    /**
+     * WHEEL_CLAMP_KEY — "Barry's release key. Feels wrong to have it."
+     * Used to attempt clamp removal without paying 10 COIN; failure = Notoriety +6, WantedStar +1. */
+    WHEEL_CLAMP_KEY("Wheel Clamp Key"),
+
+    /**
+     * STOLEN_PRINTER_INK — "HP DeskJet cartridge. Still in the sealed box. Almost certainly nicked."
+     * Crafting ingredient for FORGED_PARKING_PERMIT. Found in office blocks or bought from fence. */
+    STOLEN_PRINTER_INK("Stolen Printer Ink");
 
     private final String displayName;
 
@@ -7586,6 +7610,16 @@ public enum Material {
                                                    0.82f, 0.72f, 0.10f); // Gold label
             case HDMI_CABLE:             return c(0.18f, 0.18f, 0.20f);  // Dark grey/black cable
 
+            // Issue #1400: Northfield Residents' Parking Permit Racket
+            case PARKING_PERMIT:         return cs(0.88f, 0.92f, 0.70f, // Pale green permit
+                                                   0.18f, 0.35f, 0.18f); // Dark green text
+            case FORGED_PARKING_PERMIT:  return cs(0.88f, 0.92f, 0.70f, // Same pale green
+                                                   0.85f, 0.55f, 0.10f); // Suspicious orange text
+            case WHEEL_CLAMP_KEY:        return cs(0.15f, 0.15f, 0.18f, // Dark metal
+                                                   0.72f, 0.62f, 0.18f); // Brass key tip
+            case STOLEN_PRINTER_INK:     return cs(0.18f, 0.18f, 0.22f, // Black cartridge body
+                                                   0.55f, 0.15f, 0.62f); // Purple HP logo accent
+
             default:             return c(0.5f, 0.5f, 0.5f);
         }
     }
@@ -8156,6 +8190,11 @@ public enum Material {
             case VINYL_RECORD_BOX:
             case GENUINE_FIRST_PRESSING:
             case HDMI_CABLE:
+            // Issue #1400: Northfield Residents' Parking Permit Racket — not block items
+            case PARKING_PERMIT:
+            case FORGED_PARKING_PERMIT:
+            case WHEEL_CLAMP_KEY:
+            case STOLEN_PRINTER_INK:
                 return false;
             default:
                 return true;
@@ -9830,6 +9869,16 @@ public enum Material {
                 return IconShape.TOOL;        // telescopic squeegee handle
             case TERRY_DEBT_NOTE:
                 return IconShape.FLAT_PAPER;  // handwritten note
+
+            // Issue #1400: Northfield Residents' Parking Permit Racket
+            case PARKING_PERMIT:
+                return IconShape.FLAT_PAPER;  // laminated permit card
+            case FORGED_PARKING_PERMIT:
+                return IconShape.FLAT_PAPER;  // dodgy-looking permit card
+            case WHEEL_CLAMP_KEY:
+                return IconShape.TOOL;        // small release key
+            case STOLEN_PRINTER_INK:
+                return IconShape.BOX;         // sealed inkjet cartridge box
 
             default:
                 return IconShape.BOX;

--- a/src/main/java/ragamuffin/entity/NPCType.java
+++ b/src/main/java/ragamuffin/entity/NPCType.java
@@ -3063,7 +3063,30 @@ public enum NPCType {
      * Follows a fixed 12-property route, spending 90 in-game seconds at each. Places LADDER_PROP
      * against walls. Oblivious to player on ladder (facing wall). Becomes HOSTILE if player
      * poaches his round. HP: 20f, attack: 0f, cooldown: 0f, hostile: false. */
-    WINDOW_CLEANER(20f, 0f, 0f, false);
+    WINDOW_CLEANER(20f, 0f, 0f, false),
+
+    // ── Issue #1400: Northfield Residents' Parking Permit Racket ─────────────
+
+    /** TRAFFIC_WARDEN_BARRY — Barry, the RPZ traffic warden who patrols every 20 in-game minutes
+     * 08:00–18:00 and clamps unregistered cars with WHEEL_CLAMP_PROP.
+     * Can be bribed (3/8/20 COIN) or observed seeding BENT_WARDEN rumour.
+     * HP: 25f, attack: 0f, cooldown: 0f, hostile: false. */
+    TRAFFIC_WARDEN_BARRY(25f, 0f, 0f, false),
+
+    /** COUNCIL_CLERK — Brenda, the council office clerk who sells PARKING_PERMIT for 4 COIN.
+     * Stationed at the COUNCIL_OFFICE_KIOSK prop. Passive NPC.
+     * HP: 20f, attack: 0f, cooldown: 0f, hostile: false. */
+    COUNCIL_CLERK(20f, 0f, 0f, false),
+
+    /** REPAIR_CREW_NPC — council repair crew member who restores defaced RPZ_SIGN_PROP
+     * back to RPZ_SIGN_PROP after 3 in-game hours. Arrives 30 in-game minutes after sign is defaced.
+     * HP: 20f, attack: 0f, cooldown: 0f, hostile: false. */
+    REPAIR_CREW_NPC(20f, 0f, 0f, false),
+
+    /** DESPERATE_PARKER_NPC — a desperate driver who will buy a PARKING_PERMIT from the player
+     * for up to 12 COIN (scalping mechanic). Triggers HMRC income tracking.
+     * HP: 20f, attack: 0f, cooldown: 0f, hostile: false. */
+    DESPERATE_PARKER_NPC(20f, 0f, 0f, false);
 
     private final float maxHealth;
     private final float attackDamage;   // Damage per hit to player

--- a/src/main/java/ragamuffin/ui/AchievementType.java
+++ b/src/main/java/ragamuffin/ui/AchievementType.java
@@ -6536,6 +6536,53 @@ public enum AchievementType {
         "Bucket and Spade",
         "You nicked Terry's kit and did his round. The cheek of it is almost admirable.",
         1
+    ),
+
+    // ── Issue #1400: Northfield Residents' Parking Permit Racket ─────────────
+
+    /**
+     * SWEETENING_BARRY — successfully bribe Barry with BRIBE_HIGH (20 COIN).
+     */
+    SWEETENING_BARRY(
+        "Sweetening Barry",
+        "Twenty quid. Barry pocketed it without blinking. He's done this before.",
+        1
+    ),
+
+    /**
+     * NORTHFIELD_TICKET_TOUT — sell a PARKING_PERMIT to a DESPERATE_PARKER_NPC for 12 COIN.
+     */
+    NORTHFIELD_TICKET_TOUT(
+        "Northfield Ticket Tout",
+        "You bought it for four. Sold it for twelve. HMRC are circling.",
+        1
+    ),
+
+    /**
+     * FREE_RANGE_PARKING — park without a permit or clamp for a full in-game day (Barry on duty).
+     */
+    FREE_RANGE_PARKING(
+        "Free Range Parking",
+        "Barry patrolled all day and somehow missed you. Remarkable. Probably not repeatable.",
+        1
+    ),
+
+    /**
+     * CLAMP_ESCAPE_ARTIST — remove a WHEEL_CLAMP_PROP using WHEEL_CLAMP_KEY without being caught.
+     */
+    CLAMP_ESCAPE_ARTIST(
+        "Clamp Escape Artist",
+        "You had the key, you had the nerve, and Barry had his back turned. Perfect.",
+        1
+    ),
+
+    /**
+     * FORGER_IN_RESIDENCE — use a FORGED_PARKING_PERMIT that is not detected by Barry.
+     */
+    FORGER_IN_RESIDENCE(
+        "Forger in Residence",
+        "Comic Sans fooled the man. The bar for document security in Zone S is not high.",
+        1
     );
 
     private final String name;


### PR DESCRIPTION
## Summary
Automated fix for issue #1400.

## Changes
- Fix #1400: automated fix

Closes #1400