### PR TITLE
Fix #1402: Add Northfield Severn Trent Road Dig — The Weeks-Long Hole, the Night-Site Raid & the Council Contractor Scam

### DIFF
--- a/src/main/java/ragamuffin/building/Material.java
+++ b/src/main/java/ragamuffin/building/Material.java
@@ -6265,7 +6265,37 @@ public enum Material {
     /**
      * STOLEN_PRINTER_INK — "HP DeskJet cartridge. Still in the sealed box. Almost certainly nicked."
      * Crafting ingredient for FORGED_PARKING_PERMIT. Found in office blocks or bought from fence. */
-    STOLEN_PRINTER_INK("Stolen Printer Ink");
+    STOLEN_PRINTER_INK("Stolen Printer Ink"),
+
+    // ── Issue #1402: Northfield Severn Trent Road Dig ─────────────────────────
+
+    /**
+     * THERMOS — "Battered red thermos. Still warm. Smells of builder's tea."
+     * Always present in welfare cabin loot. Restores +8 warmth when consumed.
+     * Can be handed to CONTRACTOR_STEVE or CONTRACTOR_PHIL to raise CONTRACTOR_GOODWILL (+20 each). */
+    THERMOS("Thermos"),
+
+    /**
+     * SITE_RADIO — "Roberts radio covered in plaster dust. Tuned to Radio 2."
+     * 60% chance in welfare cabin loot. Fenceable for 4 COIN.
+     * Also usable to listen to pirate radio (PirateRadioSystem). */
+    SITE_RADIO("Site Radio"),
+
+    /**
+     * CONTRACTOR_CLIPBOARD — "Severn Trent job pack. Mostly blank variation-order forms."
+     * 40% chance in welfare cabin loot. Key item for council billing scam (Mechanic 4).
+     * Also buyable at InternetCafe for 2 COIN. */
+    CONTRACTOR_CLIPBOARD("Contractor Clipboard"),
+
+    /**
+     * HARD_HAT — "White hard hat. 'SEVERN TRENT' stencilled on the back in marker pen."
+     * Part of contractor disguise (with HI_VIS_JACKET). Bought at corner shop for 2 COIN. */
+    HARD_HAT("Hard Hat"),
+
+    /**
+     * MYSTERY_OBJECT — "You're not sure what this is. Looks old. Possibly valuable."
+     * Found in BURIED_STASH_PROP under the trench. Fenceable for 8 COIN. */
+    MYSTERY_OBJECT("Mystery Object");
 
     private final String displayName;
 
@@ -7620,6 +7650,17 @@ public enum Material {
             case STOLEN_PRINTER_INK:     return cs(0.18f, 0.18f, 0.22f, // Black cartridge body
                                                    0.55f, 0.15f, 0.62f); // Purple HP logo accent
 
+            // Issue #1402: Northfield Severn Trent Road Dig
+            case THERMOS:               return cs(0.72f, 0.15f, 0.10f, // Red thermos body
+                                                  0.85f, 0.82f, 0.75f); // Silver cup cap
+            case SITE_RADIO:            return cs(0.15f, 0.15f, 0.18f, // Plaster-dusty dark grey
+                                                  0.88f, 0.75f, 0.25f); // Tuner dial gold
+            case CONTRACTOR_CLIPBOARD:  return cs(0.72f, 0.55f, 0.30f, // Brown clipboard board
+                                                  0.92f, 0.92f, 0.88f); // White paper
+            case HARD_HAT:              return c(0.95f, 0.95f, 0.92f);  // White hard hat
+            case MYSTERY_OBJECT:        return cs(0.45f, 0.38f, 0.28f, // Earthy brown (dirty)
+                                                  0.62f, 0.55f, 0.40f); // Lighter soil highlight
+
             default:             return c(0.5f, 0.5f, 0.5f);
         }
     }
@@ -8195,6 +8236,12 @@ public enum Material {
             case FORGED_PARKING_PERMIT:
             case WHEEL_CLAMP_KEY:
             case STOLEN_PRINTER_INK:
+            // Issue #1402: Northfield Severn Trent Road Dig — not block items
+            case THERMOS:
+            case SITE_RADIO:
+            case CONTRACTOR_CLIPBOARD:
+            case HARD_HAT:
+            case MYSTERY_OBJECT:
                 return false;
             default:
                 return true;
@@ -9879,6 +9926,18 @@ public enum Material {
                 return IconShape.TOOL;        // small release key
             case STOLEN_PRINTER_INK:
                 return IconShape.BOX;         // sealed inkjet cartridge box
+
+            // Issue #1402: Northfield Severn Trent Road Dig
+            case THERMOS:
+                return IconShape.CYLINDER;    // red flask
+            case SITE_RADIO:
+                return IconShape.BOX;         // portable radio
+            case CONTRACTOR_CLIPBOARD:
+                return IconShape.FLAT_PAPER;  // clipboard with forms
+            case HARD_HAT:
+                return IconShape.BOX;         // safety helmet
+            case MYSTERY_OBJECT:
+                return IconShape.BOX;         // unidentified lump
 
             default:
                 return IconShape.BOX;

--- a/src/main/java/ragamuffin/core/RumourType.java
+++ b/src/main/java/ragamuffin/core/RumourType.java
@@ -1317,5 +1317,37 @@ public enum RumourType {
     /** "Terry was chatting to Dot about number twelve — apparently they've been at it again."
      * Seeded by WindowCleanerSystem during payment exchanges within 4 blocks of player.
      * Spreads via PUBLIC, PENSIONER NPCs. Notoriety < 25 requirement. */
-    NEIGHBOURHOOD_GOSSIP;
+    NEIGHBOURHOOD_GOSSIP,
+
+    // ── Issue #1402: Northfield Severn Trent Road Dig ─────────────────────────
+
+    /** "Severn Trent are up again on Northfield Road. Three weeks this time apparently."
+     * Seeded by SevTrentRoadDigSystem when the dig event starts (Monday 08:00).
+     * Spreads via PUBLIC, PENSIONER, SHOPKEEPER NPCs. */
+    ROAD_DIG_CHAOS,
+
+    /** "Someone's kicked all the barriers over on the roadworks. Absolute carnage."
+     * Seeded by SevTrentRoadDigSystem when player kicks ≥ 3 ORANGE_BARRIER_PROPs.
+     * Notoriety +2 (traffic disruption). Spreads via PUBLIC, DRIVER NPCs. */
+    TRAFFIC_CHAOS,
+
+    /** "Someone's had the cabin on the roadworks. Nicked the radio and everything."
+     * Seeded by SevTrentRoadDigSystem when player loots WELFARE_CABIN_PROP at night.
+     * Spreads via PUBLIC, PENSIONER, POLICE NPCs. */
+    SITE_THEFT,
+
+    /** "Those Severn Trent lads are well bent. Fifty pence and they'll do anything."
+     * Seeded by SevTrentRoadDigSystem when player bribes CONTRACTOR_STEVE or CONTRACTOR_PHIL.
+     * Spreads via PUBLIC, PENSIONER NPCs. */
+    CONTRACTOR_BRIBED,
+
+    /** "Someone's been billing the council for ghost work on the roadworks. Ballsy."
+     * Seeded by SevTrentRoadDigSystem on successful variation-order submission.
+     * Spreads via PUBLIC, JOURNALIST NPCs. */
+    COUNCIL_FRAUD,
+
+    /** "Lights on Church Road have been green both ways for an hour. It's carnage."
+     * Seeded by SevTrentRoadDigSystem when traffic lights are sabotaged into chaos mode.
+     * Spreads via PUBLIC, DRIVER, POLICE NPCs. */
+    LIGHTS_JAMMED;
 }

--- a/src/main/java/ragamuffin/entity/NPCType.java
+++ b/src/main/java/ragamuffin/entity/NPCType.java
@@ -3086,7 +3086,24 @@ public enum NPCType {
     /** DESPERATE_PARKER_NPC — a desperate driver who will buy a PARKING_PERMIT from the player
      * for up to 12 COIN (scalping mechanic). Triggers HMRC income tracking.
      * HP: 20f, attack: 0f, cooldown: 0f, hostile: false. */
-    DESPERATE_PARKER_NPC(20f, 0f, 0f, false);
+    DESPERATE_PARKER_NPC(20f, 0f, 0f, false),
+
+    // ── Issue #1402: Northfield Severn Trent Road Dig ─────────────────────────
+
+    /** CONTRACTOR_STEVE — senior Severn Trent contractor. On site 08:00–16:00 during dig event.
+     * Bribeable (BRIBE_LOW/MID/HIGH). Carries THERMOS. Can be threatened if Notoriety &lt; 20.
+     * HP: 22f, attack: 5f, cooldown: 0f, hostile: false. */
+    CONTRACTOR_STEVE(22f, 5f, 0f, false),
+
+    /** CONTRACTOR_PHIL — junior contractor. Tea-break vulnerable; on site 08:00–16:00.
+     * Will ask for THERMOS when player is in contractor disguise. Calls police if threatened at high Notoriety.
+     * HP: 20f, attack: 0f, cooldown: 0f, hostile: false. */
+    CONTRACTOR_PHIL(20f, 0f, 0f, false),
+
+    /** ROAD_RAGE_NPC — angry driver spawned when car enters ROAD_TRENCH_PROP closure or traffic chaos.
+     * Brawls with other ROAD_RAGE_NPCs; aggressive toward player. Despawns after 5 in-game minutes.
+     * HP: 25f, attack: 10f, cooldown: 0f, hostile: true. */
+    ROAD_RAGE_NPC(25f, 10f, 0f, true);
 
     private final float maxHealth;
     private final float attackDamage;   // Damage per hit to player

--- a/src/main/java/ragamuffin/ui/AchievementType.java
+++ b/src/main/java/ragamuffin/ui/AchievementType.java
@@ -6583,6 +6583,53 @@ public enum AchievementType {
         "Forger in Residence",
         "Comic Sans fooled the man. The bar for document security in Zone S is not high.",
         1
+    ),
+
+    // ── Issue #1402: Northfield Severn Trent Road Dig ─────────────────────────
+
+    /**
+     * CERTIFIED_JOBSWORTH — kick ≥ 3 ORANGE_BARRIER_PROPs then place a diversion sign pointing the wrong way.
+     */
+    CERTIFIED_JOBSWORTH(
+        "Certified Jobsworth",
+        "You kicked over the barriers and redirected traffic into a cul-de-sac. Marvellous.",
+        1
+    ),
+
+    /**
+     * GREEN_FOR_EVERYONE — successfully sabotage both temporary traffic lights in a single dig event.
+     */
+    GREEN_FOR_EVERYONE(
+        "Green for Everyone",
+        "Both lights. Green. Simultaneously. The junction held a very brief carnival.",
+        1
+    ),
+
+    /**
+     * BILLED_THE_COUNCIL — successfully claim a variation order from the council kiosk.
+     */
+    BILLED_THE_COUNCIL(
+        "Billed the Council",
+        "Emergency asbestos survey. They didn't even ask for a receipt.",
+        1
+    ),
+
+    /**
+     * CONTRACTOR_ALLIANCE — bribe CONTRACTOR_STEVE with BRIBE_HIGH (15 COIN) during a live dig event.
+     */
+    CONTRACTOR_ALLIANCE(
+        "Contractor Alliance",
+        "Fifteen quid. Steve pocketed it, winked, and handed you the shovel. Solidarity.",
+        1
+    ),
+
+    /**
+     * BURIED_TREASURE — find and loot the BURIED_STASH_PROP hidden under the trench.
+     */
+    BURIED_TREASURE(
+        "Buried Treasure",
+        "Under three weeks of Severn Trent spoil: mystery, coin, and the faint smell of drains.",
+        1
     );
 
     private final String name;

--- a/src/main/java/ragamuffin/world/PropType.java
+++ b/src/main/java/ragamuffin/world/PropType.java
@@ -3883,7 +3883,47 @@ public enum PropType {
      * Contains BUCKET_AND_CHAMOIS (stealable). Indestructible for gameplay purposes.
      * 4.5×1.8×2.0m.
      */
-    WINDOW_CLEANING_VAN_PROP(4.5f, 1.8f, 2.0f, 99, null);
+    WINDOW_CLEANING_VAN_PROP(4.5f, 1.8f, 2.0f, 99, null),
+
+    // ── Issue #1402: Northfield Severn Trent Road Dig ─────────────────────────
+
+    /**
+     * ROAD_TRENCH_PROP — Open trench cut across Northfield Road by Severn Trent.
+     * 4 blocks wide, 2 blocks deep. Blocks pedestrian and vehicle movement.
+     * Present for the duration of the dig event (5 in-game days from Monday 08:00).
+     * 4.0×2.0×4.0m; indestructible (99 hits) — only removed when dig ends.
+     */
+    ROAD_TRENCH_PROP(4.0f, 2.0f, 4.0f, 99, null),
+
+    /**
+     * ORANGE_BARRIER_PROP — Plastic traffic barrier (12 placed around trench perimeter).
+     * Kickable: hold E for 1 second to remove. Can be re-placed by player.
+     * 1.2×1.0×0.5m; 1 hit to kick over (not destroyed — just displaced).
+     */
+    ORANGE_BARRIER_PROP(1.2f, 1.0f, 0.5f, 1, null),
+
+    /**
+     * TEMP_TRAFFIC_LIGHT_PROP — Temporary traffic signal on a 90-second cycle.
+     * Can be sabotaged (BattleBarMiniGame EASY) to stick both lights on green.
+     * 0.3×2.5×0.3m; 8 hits to destroy; drops null (it's council property).
+     */
+    TEMP_TRAFFIC_LIGHT_PROP(0.3f, 2.5f, 0.3f, 8, null),
+
+    /**
+     * WELFARE_CABIN_PROP — Site welfare unit (portable cabin) on the pavement.
+     * Contains loot (THERMOS always, others probabilistic). Locked 08:00–22:00 (E shows "Locked").
+     * Night raid (22:00–05:00): press E to loot — CrimeType.THEFT_FROM_WORKSITE, Notoriety +3.
+     * 6.0×2.8×2.4m; indestructible (99 hits).
+     */
+    WELFARE_CABIN_PROP(6.0f, 2.8f, 2.4f, 99, null),
+
+    /**
+     * BURIED_STASH_PROP — Hidden under one of the trench blocks.
+     * Location revealed by CONTRACTOR_GOODWILL ≥ 40 or BRIBE_HIGH.
+     * Contains 5–10 COIN + MYSTERY_OBJECT. Press E to loot.
+     * 0.5×0.5×0.5m; 1 hit (fragile mud cover); drops MYSTERY_OBJECT.
+     */
+    BURIED_STASH_PROP(0.5f, 0.5f, 0.5f, 1, Material.MYSTERY_OBJECT);
 
     // ─────────────────────────────────────────────────────────────────────────
     // Issue #719: Collision and destructibility data


### PR DESCRIPTION
## Summary
Automated fix for issue #1402.

## Changes
- Fix #1402: automated fix

Closes #1402