### PR TITLE
Fix #1416: Add Northfield Mobile Speed Camera Van — The GATSO Trap, the Tip-Off Racket & the SD Card Heist

### DIFF
--- a/src/main/java/ragamuffin/building/Material.java
+++ b/src/main/java/ragamuffin/building/Material.java
@@ -6376,7 +6376,31 @@ public enum Material {
      * Run a rival round: 35% accept rate, 4 COIN/sale.
      * Monthly Trading Standards check (last Friday 14:00) has 20% catch chance.
      */
-    KNOCKOFF_CATALOGUE("Knockoff Catalogue");
+    KNOCKOFF_CATALOGUE("Knockoff Catalogue"),
+
+    // ── Issue #1416: Northfield Mobile Speed Camera Van ───────────────────────
+
+    /**
+     * SPEED_CAMERA_SD_CARD — the SD card from Sharon's GATSO speed camera.
+     * Stolen by holding E on SPEED_CAMERA_VAN_PROP for 4 seconds while Sharon is distracted.
+     * Sell to FenceSystem (20 COIN), a SPEEDING_DRIVER_NPC (15 COIN + GRATEFUL_DRIVER rumour),
+     * or a journalist via phone box (30 COIN, triggers police patrol increase).
+     * Achievement: CANDID_CAMERA after 3 steals.
+     */
+    SPEED_CAMERA_SD_CARD("Speed Camera SD Card"),
+
+    /**
+     * SPEEDING_FINE_NOTICE — an official speeding fine notice photographed by the GATSO.
+     * Produced when a car is flashed. Sellable or usable as evidence.
+     */
+    SPEEDING_FINE_NOTICE("Speeding Fine Notice"),
+
+    /**
+     * HANDWRITTEN_WARNING_SIGN — a cardboard sign warning drivers of the speed camera ahead.
+     * Crafted from MARKER_PEN + CARDBOARD. Placed as HANDWRITTEN_WARNING_SIGN_PROP on the road.
+     * Automatically warns approaching SPEEDING_DRIVER_NPCs for 10 in-game minutes.
+     */
+    HANDWRITTEN_WARNING_SIGN("Handwritten Warning Sign");
 
     private final String displayName;
 
@@ -7764,6 +7788,13 @@ public enum Material {
             case ROOF_SLATE_BAG:        return cs(0.28f, 0.28f, 0.30f, // Dark slate grey
                                                    0.48f, 0.42f, 0.38f); // Worn canvas bag
 
+            // Issue #1416: Northfield Mobile Speed Camera Van
+            case SPEED_CAMERA_SD_CARD:  return c(0.20f, 0.20f, 0.22f);  // Dark plastic card
+            case SPEEDING_FINE_NOTICE:  return cs(0.95f, 0.90f, 0.70f, // Cream paper
+                                                   0.15f, 0.25f, 0.60f); // Blue police heading
+            case HANDWRITTEN_WARNING_SIGN: return cs(0.75f, 0.62f, 0.38f, // Cardboard
+                                                     0.05f, 0.05f, 0.05f); // Black marker text
+
             default:             return c(0.5f, 0.5f, 0.5f);
         }
     }
@@ -8358,6 +8389,11 @@ public enum Material {
             case CASH_ENVELOPE:
             case ROOF_SLATE_BAG:
                 return false;
+            // Issue #1416: Northfield Mobile Speed Camera Van — not block items
+            case SPEED_CAMERA_SD_CARD:
+            case SPEEDING_FINE_NOTICE:
+            case HANDWRITTEN_WARNING_SIGN:
+                return false;
             default:
                 return true;
         }
@@ -8564,6 +8600,10 @@ public enum Material {
             case RAW_PUMPKIN:
             case CARVED_PUMPKIN:
             case PUMPKIN_INNARDS:
+            // Issue #1416: Northfield Mobile Speed Camera Van — small items sit on surfaces
+            case SPEED_CAMERA_SD_CARD:
+            case SPEEDING_FINE_NOTICE:
+            case HANDWRITTEN_WARNING_SIGN:
                 return true;
             default:
                 return false;
@@ -10075,6 +10115,14 @@ public enum Material {
                 return IconShape.FLAT_PAPER;  // bulging manila envelope
             case ROOF_SLATE_BAG:
                 return IconShape.BOX;         // heavy canvas bag of slates
+
+            // Issue #1416: Northfield Mobile Speed Camera Van
+            case SPEED_CAMERA_SD_CARD:
+                return IconShape.FLAT_PAPER;  // small plastic SD card
+            case SPEEDING_FINE_NOTICE:
+                return IconShape.FLAT_PAPER;  // official notice document
+            case HANDWRITTEN_WARNING_SIGN:
+                return IconShape.FLAT_PAPER;  // cardboard sign with marker text
 
             default:
                 return IconShape.BOX;

--- a/src/main/java/ragamuffin/core/CriminalRecord.java
+++ b/src/main/java/ragamuffin/core/CriminalRecord.java
@@ -1247,7 +1247,21 @@ public class CriminalRecord {
          * Penalty: Notoriety +8, WantedSystem +1 star; COUNTERFEIT_FINE deducted from COIN.
          * COUNTERFEIT_CAUGHT rumour seeded to nearby NPCs.
          */
-        COUNTERFEIT_GOODS_SELLING("Selling counterfeit catalogue goods");
+        COUNTERFEIT_GOODS_SELLING("Selling counterfeit catalogue goods"),
+
+        // ── Issue #1416: Northfield Mobile Speed Camera Van ───────────────────
+
+        /**
+         * CAMERA_TAMPERING — Recorded when the player interferes with the speed camera or van:
+         * <ul>
+         *   <li>Stealing the SD card (hold-E heist) — Notoriety +6.</li>
+         *   <li>Spraying paint on the camera lens (GraffitiSystem) — Notoriety +4.</li>
+         *   <li>Slashing the van tyres with CROWBAR — Notoriety +6, WantedSystem +1.</li>
+         *   <li>Burning the van with LIGHTER — Notoriety +20, WantedSystem +3.</li>
+         * </ul>
+         * Having a CAMERA_TAMPERING record blocks the Legitimate Operator Licence application.
+         */
+        CAMERA_TAMPERING("Interference with a speed enforcement device");
 
         private final String displayName;
 

--- a/src/main/java/ragamuffin/core/RumourType.java
+++ b/src/main/java/ragamuffin/core/RumourType.java
@@ -1427,5 +1427,32 @@ public enum RumourType {
      *   check (doRivalCatalogueSale catch path).
      * Spreads via PUBLIC, PENSIONER, and MARKET_TRADER NPCs.
      * Triggers COUNTERFEIT_GOODS_SELLING CriminalRecord entry and COUNTERFEIT_FINE deduction. */
-    COUNTERFEIT_CAUGHT;
+    COUNTERFEIT_CAUGHT,
+
+    // ── Issue #1416: Northfield Mobile Speed Camera Van ───────────────────────
+
+    /** "That camera van's been flashing again all morning — half the school run got caught."
+     * — seeded by SpeedCameraVanSystem when a car is photographed by the GATSO (flashCount increments).
+     * Spreads via PUBLIC and PENSIONER NPCs near the school-run zone.
+     * Raises local awareness; drivers slow down for 5 in-game minutes. */
+    CAMERA_FLASH_RUMOUR,
+
+    /** "A bloke warned me about that camera van this morning. Absolute legend."
+     * — seeded by SpeedCameraVanSystem when a SPEEDING_DRIVER_NPC buys the SD card from the player.
+     * Spreads via PUBLIC and CAR_DRIVER NPCs.
+     * Reduces police patrol frequency by 1 for the day. */
+    GRATEFUL_DRIVER,
+
+    /** "Someone's sold footage from that speed camera to the Gazette. Turns out it photographed
+     *   something it shouldn't have."
+     * — seeded by SpeedCameraVanSystem when the player sells the SD card to a journalist via phone box.
+     * Spreads via PUBLIC, NEWSAGENT, and POLICE NPCs.
+     * Triggers police patrol increase and Wanted +1. */
+    EXPOSE_RUMOUR,
+
+    /** "Speed camera van's been torched. Just the shell left. Police are calling it deliberate."
+     * — seeded by SpeedCameraVanSystem when the player burns the van with a LIGHTER.
+     * Spreads via ALL NPC types in a wide radius.
+     * Triggers ARSON crime, newspaper headline, Notoriety +20, Wanted +3. */
+    VAN_FIRE_RUMOUR;
 }

--- a/src/main/java/ragamuffin/core/SpeedCameraVanSystem.java
+++ b/src/main/java/ragamuffin/core/SpeedCameraVanSystem.java
@@ -1,0 +1,829 @@
+package ragamuffin.core;
+
+import ragamuffin.building.Inventory;
+import ragamuffin.building.Material;
+import ragamuffin.core.CriminalRecord.CrimeType;
+import ragamuffin.core.NotorietySystem.AchievementCallback;
+import ragamuffin.entity.NPC;
+import ragamuffin.entity.NPCType;
+import ragamuffin.ui.AchievementType;
+import ragamuffin.world.PropType;
+
+import java.util.Random;
+
+/**
+ * Issue #1416: Northfield Mobile Speed Camera Van — The GATSO Trap, the Tip-Off
+ * Racket &amp; the SD Card Heist.
+ *
+ * <h3>Mechanic 1 — The GATSO Trap</h3>
+ * <ul>
+ *   <li>{@link NPCType#CAMERA_OPERATOR_NPC} Sharon sits in
+ *       {@link PropType#SPEED_CAMERA_VAN_PROP} reading a tabloid.</li>
+ *   <li>Active weekdays (Mon–Fri) during school-run windows:
+ *       08:00–09:30 and 15:30–17:00.</li>
+ *   <li>Cars exceeding {@link #SPEED_LIMIT_MPH} = 30 within
+ *       {@link #CAMERA_RANGE_BLOCKS} = 12 blocks are photographed
+ *       ({@code flashCount} increments, {@link RumourType#CAMERA_FLASH_RUMOUR} seeded).</li>
+ *   <li>Player can distract Sharon using {@link PropType#TABLOID_RACK_PROP}
+ *       for {@link #DISTRACTION_SECONDS} = 25 seconds.</li>
+ * </ul>
+ *
+ * <h3>Mechanic 2 — Tip-Off Racket</h3>
+ * <ul>
+ *   <li>Player can wave down approaching cars (E on {@link NPCType#SPEEDING_DRIVER_NPC})
+ *       for {@link #TIP_OFF_COIN_REWARD} = 2 COIN each.</li>
+ *   <li>After 5 tips Sharon radios police (WantedSystem +1).</li>
+ *   <li>Player can craft and place {@link PropType#HANDWRITTEN_WARNING_SIGN_PROP}
+ *       (MARKER_PEN + CARDBOARD) on the road to warn drivers automatically for
+ *       {@link #WARNING_SIGN_DURATION_MINUTES} = 10 in-game minutes.</li>
+ *   <li>Achievement: {@link AchievementType#SPEED_ANGEL} after 5 tip-offs.</li>
+ * </ul>
+ *
+ * <h3>Mechanic 3 — SD Card Heist</h3>
+ * <ul>
+ *   <li>Hold E on van for {@link #SD_CARD_STEAL_DURATION} = 4 seconds while
+ *       Sharon is distracted to steal {@link Material#SPEED_CAMERA_SD_CARD}.</li>
+ *   <li>Sell to FenceSystem (20 COIN), a flashed driver (15 COIN +
+ *       {@link RumourType#GRATEFUL_DRIVER} rumour), or a journalist via phone box
+ *       (30 COIN but triggers police patrol increase).</li>
+ *   <li>Achievement: {@link AchievementType#CANDID_CAMERA} after 3 steals.</li>
+ * </ul>
+ *
+ * <h3>Mechanic 4 — Lens Fogging &amp; Vandalism</h3>
+ * <ul>
+ *   <li>Spray paint lens (GraffitiSystem) — blind camera for
+ *       {@link #LENS_FOG_DURATION_MINUTES} = 30 minutes (+4 Notoriety).</li>
+ *   <li>Slash tyres with CROWBAR — van removed in 60 minutes (+6 Notoriety,
+ *       WantedSystem +1). Achievement: {@link AchievementType#FLAT_TYRE_SHARON}.</li>
+ *   <li>Burn van with LIGHTER when Sharon absent (+20 Notoriety, WantedSystem +3,
+ *       {@link CrimeType#ARSON}, newspaper headline).
+ *       Achievement: {@link AchievementType#SPEED_LIMIT_ABOLISHED}.</li>
+ * </ul>
+ *
+ * <h3>Mechanic 5 — Legitimate Operator Licence</h3>
+ * <ul>
+ *   <li>Apply at police station (5 COIN, no prior {@link CrimeType#CAMERA_TAMPERING})
+ *       to work beside Sharon legally.</li>
+ *   <li>Earns 1 COIN/hour + fine revenue share logged by HMRCSystem.</li>
+ *   <li>Achievement: {@link AchievementType#POACHER_TURNED_GAMEKEEPER}.</li>
+ * </ul>
+ */
+public class SpeedCameraVanSystem {
+
+    // ── Schedule ───────────────────────────────────────────────────────────────
+
+    /** Morning school-run start hour (08:00). */
+    public static final float MORNING_START = 8.0f;
+
+    /** Morning school-run end hour (09:30). */
+    public static final float MORNING_END = 9.5f;
+
+    /** Afternoon school-run start hour (15:30). */
+    public static final float AFTERNOON_START = 15.5f;
+
+    /** Afternoon school-run end hour (17:00). */
+    public static final float AFTERNOON_END = 17.0f;
+
+    // ── Camera constants ───────────────────────────────────────────────────────
+
+    /** Speed limit in mph. Cars exceeding this are photographed. */
+    public static final int SPEED_LIMIT_MPH = 30;
+
+    /** Range in blocks within which the GATSO can photograph cars. */
+    public static final float CAMERA_RANGE_BLOCKS = 12f;
+
+    /** Probability (0–1) that any given passing car exceeds the speed limit. */
+    public static final float SPEEDING_CAR_CHANCE = 0.30f;
+
+    // ── Mechanic 1 — Distraction ───────────────────────────────────────────────
+
+    /** Seconds Sharon is distracted after player interacts with TABLOID_RACK_PROP. */
+    public static final float DISTRACTION_SECONDS = 25.0f;
+
+    // ── Mechanic 2 — Tip-Off Racket ───────────────────────────────────────────
+
+    /** COIN reward for tipping off a single approaching driver (E on SPEEDING_DRIVER_NPC). */
+    public static final int TIP_OFF_COIN_REWARD = 2;
+
+    /** Number of tip-offs before Sharon radios police (WantedSystem +1). */
+    public static final int TIP_OFFS_BEFORE_POLICE_CALL = 5;
+
+    /** Duration in in-game minutes a HANDWRITTEN_WARNING_SIGN_PROP stays active. */
+    public static final float WARNING_SIGN_DURATION_MINUTES = 10.0f;
+
+    /** Number of tip-offs needed for SPEED_ANGEL achievement. */
+    public static final int SPEED_ANGEL_THRESHOLD = 5;
+
+    // ── Mechanic 3 — SD Card Heist ────────────────────────────────────────────
+
+    /** Hold-E duration (seconds) to steal the SPEED_CAMERA_SD_CARD. */
+    public static final float SD_CARD_STEAL_DURATION = 4.0f;
+
+    /** COIN received when selling SD card to FenceSystem. */
+    public static final int SD_CARD_FENCE_VALUE = 20;
+
+    /** COIN received when selling SD card to a flashed SPEEDING_DRIVER_NPC. */
+    public static final int SD_CARD_DRIVER_VALUE = 15;
+
+    /** COIN received when selling SD card to a journalist via phone box. */
+    public static final int SD_CARD_JOURNALIST_VALUE = 30;
+
+    /** Number of SD card steals needed for CANDID_CAMERA achievement. */
+    public static final int CANDID_CAMERA_THRESHOLD = 3;
+
+    /** Notoriety added on SD card theft. */
+    public static final int SD_CARD_THEFT_NOTORIETY = 6;
+
+    // ── Mechanic 4 — Vandalism ────────────────────────────────────────────────
+
+    /** Duration in in-game minutes a fogged camera lens stays blinded. */
+    public static final float LENS_FOG_DURATION_MINUTES = 30.0f;
+
+    /** Notoriety penalty for fogging the camera lens. */
+    public static final int LENS_FOG_NOTORIETY = 4;
+
+    /** Notoriety penalty for slashing the van's tyres. */
+    public static final int TYRE_SLASH_NOTORIETY = 6;
+
+    /** WantedSystem stars added when tyres are slashed. */
+    public static final int TYRE_SLASH_WANTED_STARS = 1;
+
+    /** Notoriety penalty for burning the van. */
+    public static final int VAN_FIRE_NOTORIETY = 20;
+
+    /** WantedSystem stars added when the van is burned. */
+    public static final int VAN_FIRE_WANTED_STARS = 3;
+
+    // ── Mechanic 5 — Legitimate Licence ──────────────────────────────────────
+
+    /** COIN cost to apply for an Operator Licence at the police station. */
+    public static final int LICENCE_APPLICATION_COST = 5;
+
+    /** COIN earned per in-game hour while working legitimately beside Sharon. */
+    public static final int LEGITIMATE_EARNINGS_PER_HOUR = 1;
+
+    // ── Result enums ──────────────────────────────────────────────────────────
+
+    /** Result of attempting to steal the SD card. */
+    public enum SdCardHeistResult {
+        /** Card successfully stolen; SPEED_CAMERA_SD_CARD added to inventory. */
+        STOLEN,
+        /** Sharon is not distracted — heist window not open. */
+        SHARON_WATCHING,
+        /** Van is not active (outside school-run hours or weekend). */
+        VAN_NOT_ACTIVE,
+        /** Player already holds the SD card. */
+        ALREADY_STOLEN
+    }
+
+    /** Result of tipping off a driver (E on SPEEDING_DRIVER_NPC). */
+    public enum TipOffResult {
+        /** Driver warned; TIP_OFF_COIN_REWARD COIN awarded. */
+        TIPPED,
+        /** Sharon noticed the tip-off and radioed police (Wanted +1). */
+        SHARON_RADIOED_POLICE,
+        /** Van not currently active. */
+        VAN_NOT_ACTIVE
+    }
+
+    /** Result of selling the SD card to a flashed driver. */
+    public enum SdCardSaleResult {
+        /** Sale made; SD_CARD_DRIVER_VALUE COIN awarded; GRATEFUL_DRIVER rumour seeded. */
+        SOLD,
+        /** Player does not have an SD card. */
+        NO_SD_CARD,
+        /** Driver refuses (Sharon was not photographing at time of flash). */
+        DRIVER_REFUSES
+    }
+
+    /** Result of applying for an Operator Licence. */
+    public enum LicenceApplicationResult {
+        /** Licence granted; player can now work legally beside Sharon. */
+        GRANTED,
+        /** Player has a CAMERA_TAMPERING record — application refused. */
+        REFUSED_CRIMINAL_RECORD,
+        /** Player cannot afford the 5 COIN fee. */
+        INSUFFICIENT_FUNDS
+    }
+
+    /** Result of slashing the van's tyres. */
+    public enum TyreSlashResult {
+        /** Tyres slashed successfully; van to be removed in 60 minutes. */
+        SLASHED,
+        /** Player does not have a CROWBAR. */
+        NO_CROWBAR,
+        /** Tyres already slashed. */
+        ALREADY_SLASHED
+    }
+
+    /** Result of burning the van. */
+    public enum VanArsonResult {
+        /** Van set on fire; newspaper headline triggered. */
+        BURNED,
+        /** Sharon is still present — cannot burn while operator is inside. */
+        SHARON_PRESENT,
+        /** Player does not have a LIGHTER. */
+        NO_LIGHTER,
+        /** Van already destroyed. */
+        VAN_DESTROYED
+    }
+
+    // ── State ──────────────────────────────────────────────────────────────────
+
+    private final Random random;
+
+    /** Whether the van is currently active and deployed. */
+    private boolean vanActive = false;
+
+    /** Whether Sharon is currently distracted. */
+    private boolean sharonDistracted = false;
+
+    /** Remaining seconds of Sharon's distraction. */
+    private float distractionTimer = 0f;
+
+    /** Total number of cars flashed this session. */
+    private int flashCount = 0;
+
+    /** Number of driver tip-offs the player has made this session. */
+    private int tipOffCount = 0;
+
+    /** Number of SD card steals. */
+    private int sdCardSteals = 0;
+
+    /** Whether the SD card has already been stolen this deployment. */
+    private boolean sdCardStolenThisDeployment = false;
+
+    /** Whether a HANDWRITTEN_WARNING_SIGN_PROP is currently active on the road. */
+    private boolean warningSIgnActive = false;
+
+    /** Remaining in-game seconds of the warning sign's effect. */
+    private float warningSignTimer = 0f;
+
+    /** Whether the camera lens has been fogged by graffiti. */
+    private boolean lensFogged = false;
+
+    /** Remaining in-game seconds of the lens-fog effect. */
+    private float lensFogTimer = 0f;
+
+    /** Whether the tyres have been slashed. */
+    private boolean tyresSlashed = false;
+
+    /** Whether the van has been destroyed (burned). */
+    private boolean vanDestroyed = false;
+
+    /** Whether the player holds a Legitimate Operator Licence. */
+    private boolean hasOperatorLicence = false;
+
+    /** Whether Sharon has radioed police this deployment. */
+    private boolean sharonRadioedPolice = false;
+
+    // ── Achievement flags ──────────────────────────────────────────────────────
+
+    private boolean speedAngelAwarded = false;
+    private boolean candidCameraAwarded = false;
+    private boolean flatTyreSharonAwarded = false;
+    private boolean speedLimitAbolishedAwarded = false;
+    private boolean poacherTurnedGamekeeperAwarded = false;
+
+    // ── Optional integrations ──────────────────────────────────────────────────
+
+    private NotorietySystem notorietySystem;
+    private WantedSystem wantedSystem;
+    private CriminalRecord criminalRecord;
+    private RumourNetwork rumourNetwork;
+    private HMRCSystem hmrcSystem;
+
+    // ── Construction ───────────────────────────────────────────────────────────
+
+    public SpeedCameraVanSystem(Random random) {
+        this.random = random;
+    }
+
+    // ── Dependency injection ───────────────────────────────────────────────────
+
+    public void setNotorietySystem(NotorietySystem notorietySystem) {
+        this.notorietySystem = notorietySystem;
+    }
+
+    public void setWantedSystem(WantedSystem wantedSystem) {
+        this.wantedSystem = wantedSystem;
+    }
+
+    public void setCriminalRecord(CriminalRecord criminalRecord) {
+        this.criminalRecord = criminalRecord;
+    }
+
+    public void setRumourNetwork(RumourNetwork rumourNetwork) {
+        this.rumourNetwork = rumourNetwork;
+    }
+
+    public void setHmrcSystem(HMRCSystem hmrcSystem) {
+        this.hmrcSystem = hmrcSystem;
+    }
+
+    // ── Per-frame update ───────────────────────────────────────────────────────
+
+    /**
+     * Update the speed camera van system each frame.
+     *
+     * @param delta     seconds since last frame
+     * @param hour      current in-game hour (0–24)
+     * @param dayOfWeek 0=Sunday, 1=Monday … 6=Saturday
+     * @param sharonNpc the CAMERA_OPERATOR_NPC (may be null)
+     * @param cb        achievement callback (may be null)
+     */
+    public void update(float delta, float hour, int dayOfWeek, NPC sharonNpc,
+                       AchievementCallback cb) {
+
+        // Tick distraction timer
+        if (sharonDistracted) {
+            distractionTimer -= delta;
+            if (distractionTimer <= 0f) {
+                distractionTimer = 0f;
+                sharonDistracted = false;
+            }
+        }
+
+        // Tick lens fog timer
+        if (lensFogged) {
+            lensFogTimer -= delta;
+            if (lensFogTimer <= 0f) {
+                lensFogTimer = 0f;
+                lensFogged = false;
+            }
+        }
+
+        // Tick warning sign timer
+        if (warningSIgnActive) {
+            warningSignTimer -= delta;
+            if (warningSignTimer <= 0f) {
+                warningSignTimer = 0f;
+                warningSIgnActive = false;
+            }
+        }
+
+        // Determine whether van should be active
+        boolean shouldBeActive = isWeekday(dayOfWeek)
+                && isSchoolRunWindow(hour)
+                && !vanDestroyed;
+
+        if (!shouldBeActive) {
+            if (vanActive) {
+                endDeployment();
+            }
+            return;
+        }
+
+        if (!vanActive) {
+            startDeployment();
+        }
+
+        // Simulate car flashes (only when camera is operational)
+        if (!lensFogged && !sharonDistracted) {
+            tickCarFlashes(delta, sharonNpc, cb);
+        }
+    }
+
+    private boolean isWeekday(int dayOfWeek) {
+        // 0=Sunday, 6=Saturday are weekends
+        return dayOfWeek >= 1 && dayOfWeek <= 5;
+    }
+
+    /**
+     * Returns true if the given hour falls within a school-run window
+     * (08:00–09:30 or 15:30–17:00).
+     */
+    public boolean isSchoolRunWindow(float hour) {
+        return (hour >= MORNING_START && hour < MORNING_END)
+                || (hour >= AFTERNOON_START && hour < AFTERNOON_END);
+    }
+
+    private void startDeployment() {
+        vanActive = true;
+        sdCardStolenThisDeployment = false;
+        sharonDistracted = false;
+        sharonRadioedPolice = false;
+    }
+
+    private void endDeployment() {
+        vanActive = false;
+        sharonDistracted = false;
+    }
+
+    /**
+     * Simulate a single camera flash event triggered by a passing speeding car.
+     * Called internally; exposed for testing.
+     *
+     * @param sharonNpc the operator NPC (used for rumour seeding; may be null)
+     * @param cb        achievement callback (may be null)
+     */
+    void tickCarFlashes(float delta, NPC sharonNpc, AchievementCallback cb) {
+        // Roughly one car every 5 in-game seconds; roll per frame
+        float flashProbPerFrame = delta * SPEEDING_CAR_CHANCE / 5.0f;
+        if (random.nextFloat() < flashProbPerFrame) {
+            recordFlash(sharonNpc, cb);
+        }
+    }
+
+    /**
+     * Record a single GATSO flash event: increments flashCount and seeds the
+     * {@link RumourType#CAMERA_FLASH_RUMOUR}.
+     *
+     * @param sharonNpc the operator NPC (may be null)
+     * @param cb        achievement callback (may be null)
+     */
+    public void recordFlash(NPC sharonNpc, AchievementCallback cb) {
+        flashCount++;
+        if (rumourNetwork != null && sharonNpc != null) {
+            rumourNetwork.addRumour(sharonNpc,
+                    new Rumour(RumourType.CAMERA_FLASH_RUMOUR,
+                            "That camera van's been flashing again — half the school run got caught."));
+        }
+    }
+
+    // ── Mechanic 1 — Distraction ───────────────────────────────────────────────
+
+    /**
+     * Player interacts with the {@link PropType#TABLOID_RACK_PROP}, distracting Sharon
+     * for {@link #DISTRACTION_SECONDS} seconds.
+     */
+    public void distractSharon() {
+        sharonDistracted = true;
+        distractionTimer = DISTRACTION_SECONDS;
+    }
+
+    // ── Mechanic 2 — Tip-Off Racket ───────────────────────────────────────────
+
+    /**
+     * Player waves down a {@link NPCType#SPEEDING_DRIVER_NPC} (press E) to warn them
+     * about the speed camera, receiving {@link #TIP_OFF_COIN_REWARD} COIN.
+     *
+     * <p>After {@link #TIP_OFFS_BEFORE_POLICE_CALL} tip-offs, Sharon notices and
+     * radios police (WantedSystem +1).
+     *
+     * @param inventory player inventory
+     * @param cb        achievement callback (may be null)
+     * @return result of the tip-off
+     */
+    public TipOffResult tipOffDriver(Inventory inventory, AchievementCallback cb) {
+        if (!vanActive) return TipOffResult.VAN_NOT_ACTIVE;
+
+        tipOffCount++;
+        inventory.addItem(Material.COIN, TIP_OFF_COIN_REWARD);
+
+        // Check SPEED_ANGEL achievement
+        if (!speedAngelAwarded && tipOffCount >= SPEED_ANGEL_THRESHOLD) {
+            speedAngelAwarded = true;
+            if (cb != null) cb.award(AchievementType.SPEED_ANGEL);
+        }
+
+        // After threshold tip-offs, Sharon radios police
+        if (!sharonRadioedPolice && tipOffCount >= TIP_OFFS_BEFORE_POLICE_CALL) {
+            sharonRadioedPolice = true;
+            if (wantedSystem != null) {
+                wantedSystem.addWantedStars(1, 0f, 0f, 0f, cb);
+            }
+            return TipOffResult.SHARON_RADIOED_POLICE;
+        }
+
+        return TipOffResult.TIPPED;
+    }
+
+    /**
+     * Player places a {@link PropType#HANDWRITTEN_WARNING_SIGN_PROP} on the road.
+     * Requires a {@link Material#HANDWRITTEN_WARNING_SIGN} in inventory.
+     * The sign warns drivers automatically for {@link #WARNING_SIGN_DURATION_MINUTES}
+     * in-game minutes.
+     *
+     * @param inventory player inventory
+     * @return true if sign was placed, false if player lacks the item
+     */
+    public boolean placeWarningSign(Inventory inventory) {
+        if (inventory.getItemCount(Material.HANDWRITTEN_WARNING_SIGN) < 1) return false;
+        inventory.removeItem(Material.HANDWRITTEN_WARNING_SIGN, 1);
+        warningSIgnActive = true;
+        // WARNING_SIGN_DURATION_MINUTES converted to seconds (in-game minutes = real seconds here)
+        warningSignTimer = WARNING_SIGN_DURATION_MINUTES * 60f;
+        return true;
+    }
+
+    // ── Mechanic 3 — SD Card Heist ────────────────────────────────────────────
+
+    /**
+     * Player attempts to steal the {@link Material#SPEED_CAMERA_SD_CARD} from the van.
+     * Requires holding E for {@link #SD_CARD_STEAL_DURATION} seconds while Sharon is
+     * distracted. Call this after the hold-E timer has expired.
+     *
+     * @param inventory player inventory
+     * @param cb        achievement callback (may be null)
+     * @return result of the heist attempt
+     */
+    public SdCardHeistResult stealSdCard(Inventory inventory, AchievementCallback cb) {
+        if (!vanActive) return SdCardHeistResult.VAN_NOT_ACTIVE;
+        if (!sharonDistracted) return SdCardHeistResult.SHARON_WATCHING;
+        if (sdCardStolenThisDeployment) return SdCardHeistResult.ALREADY_STOLEN;
+
+        // Steal the card
+        sdCardStolenThisDeployment = true;
+        sdCardSteals++;
+        inventory.addItem(Material.SPEED_CAMERA_SD_CARD, 1);
+
+        // Record crime
+        if (criminalRecord != null) {
+            criminalRecord.record(CrimeType.CAMERA_TAMPERING);
+        }
+
+        // Notoriety
+        if (notorietySystem != null) {
+            notorietySystem.addNotoriety(SD_CARD_THEFT_NOTORIETY, cb);
+        }
+
+        // CANDID_CAMERA achievement
+        if (!candidCameraAwarded && sdCardSteals >= CANDID_CAMERA_THRESHOLD) {
+            candidCameraAwarded = true;
+            if (cb != null) cb.award(AchievementType.CANDID_CAMERA);
+        }
+
+        return SdCardHeistResult.STOLEN;
+    }
+
+    /**
+     * Player sells the stolen {@link Material#SPEED_CAMERA_SD_CARD} to a
+     * {@link NPCType#SPEEDING_DRIVER_NPC} who was previously flashed.
+     *
+     * <p>Pays {@link #SD_CARD_DRIVER_VALUE} COIN and seeds a
+     * {@link RumourType#GRATEFUL_DRIVER} rumour.
+     *
+     * @param inventory   player inventory
+     * @param driverNpc   the SPEEDING_DRIVER_NPC (may be null for testing)
+     * @param cb          achievement callback (may be null)
+     * @return result of the sale
+     */
+    public SdCardSaleResult sellSdCardToDriver(Inventory inventory, NPC driverNpc,
+                                               AchievementCallback cb) {
+        if (inventory.getItemCount(Material.SPEED_CAMERA_SD_CARD) < 1) {
+            return SdCardSaleResult.NO_SD_CARD;
+        }
+        if (flashCount == 0) {
+            return SdCardSaleResult.DRIVER_REFUSES;
+        }
+
+        inventory.removeItem(Material.SPEED_CAMERA_SD_CARD, 1);
+        inventory.addItem(Material.COIN, SD_CARD_DRIVER_VALUE);
+
+        if (rumourNetwork != null && driverNpc != null) {
+            rumourNetwork.addRumour(driverNpc,
+                    new Rumour(RumourType.GRATEFUL_DRIVER,
+                            "A bloke warned me about that camera van this morning. Absolute legend."));
+        }
+
+        return SdCardSaleResult.SOLD;
+    }
+
+    /**
+     * Player sells the stolen {@link Material#SPEED_CAMERA_SD_CARD} to a journalist
+     * contact via the phone box, earning {@link #SD_CARD_JOURNALIST_VALUE} COIN.
+     *
+     * <p>Triggers a police patrol increase (WantedSystem +1) and seeds an
+     * {@link RumourType#EXPOSE_RUMOUR}.
+     *
+     * @param inventory  player inventory
+     * @param sharonNpc  the CAMERA_OPERATOR_NPC (may be null for testing)
+     * @param cb         achievement callback (may be null)
+     * @return COIN paid, or 0 if the player had no card
+     */
+    public int sellSdCardToJournalist(Inventory inventory, NPC sharonNpc,
+                                      AchievementCallback cb) {
+        if (inventory.getItemCount(Material.SPEED_CAMERA_SD_CARD) < 1) return 0;
+
+        inventory.removeItem(Material.SPEED_CAMERA_SD_CARD, 1);
+        inventory.addItem(Material.COIN, SD_CARD_JOURNALIST_VALUE);
+
+        // Police patrol increase
+        if (wantedSystem != null) {
+            wantedSystem.addWantedStars(1, 0f, 0f, 0f, cb);
+        }
+
+        // Seed exposé rumour
+        if (rumourNetwork != null && sharonNpc != null) {
+            rumourNetwork.addRumour(sharonNpc,
+                    new Rumour(RumourType.EXPOSE_RUMOUR,
+                            "Someone's sold footage from that speed camera to the Gazette."));
+        }
+
+        return SD_CARD_JOURNALIST_VALUE;
+    }
+
+    // ── Mechanic 4 — Vandalism ────────────────────────────────────────────────
+
+    /**
+     * GraffitiSystem calls this when the player sprays the camera lens.
+     * Blinds the camera for {@link #LENS_FOG_DURATION_MINUTES} in-game minutes
+     * and adds {@link #LENS_FOG_NOTORIETY} Notoriety.
+     *
+     * @param cb achievement callback (may be null)
+     */
+    public void fogCameraLens(AchievementCallback cb) {
+        lensFogged = true;
+        lensFogTimer = LENS_FOG_DURATION_MINUTES * 60f;
+
+        if (criminalRecord != null) {
+            criminalRecord.record(CrimeType.CAMERA_TAMPERING);
+        }
+        if (notorietySystem != null) {
+            notorietySystem.addNotoriety(LENS_FOG_NOTORIETY, cb);
+        }
+    }
+
+    /**
+     * Player slashes the van's tyres with a CROWBAR.
+     * Removes the van from service after 60 minutes (+6 Notoriety, WantedSystem +1).
+     * Achievement: {@link AchievementType#FLAT_TYRE_SHARON}.
+     *
+     * @param inventory player inventory
+     * @param cb        achievement callback (may be null)
+     * @return result of the tyre-slash attempt
+     */
+    public TyreSlashResult slashTyres(Inventory inventory, AchievementCallback cb) {
+        if (inventory.getItemCount(Material.CROWBAR) < 1) {
+            return TyreSlashResult.NO_CROWBAR;
+        }
+        if (tyresSlashed) {
+            return TyreSlashResult.ALREADY_SLASHED;
+        }
+
+        tyresSlashed = true;
+
+        if (criminalRecord != null) {
+            criminalRecord.record(CrimeType.CAMERA_TAMPERING);
+        }
+        if (notorietySystem != null) {
+            notorietySystem.addNotoriety(TYRE_SLASH_NOTORIETY, cb);
+        }
+        if (wantedSystem != null) {
+            wantedSystem.addWantedStars(TYRE_SLASH_WANTED_STARS, 0f, 0f, 0f, cb);
+        }
+
+        if (!flatTyreSharonAwarded) {
+            flatTyreSharonAwarded = true;
+            if (cb != null) cb.award(AchievementType.FLAT_TYRE_SHARON);
+        }
+
+        return TyreSlashResult.SLASHED;
+    }
+
+    /**
+     * Player burns the van with a LIGHTER while Sharon is absent.
+     * +{@link #VAN_FIRE_NOTORIETY} Notoriety, WantedSystem +{@link #VAN_FIRE_WANTED_STARS},
+     * {@link CrimeType#ARSON} crime, seeds {@link RumourType#VAN_FIRE_RUMOUR}.
+     * Achievement: {@link AchievementType#SPEED_LIMIT_ABOLISHED}.
+     *
+     * @param inventory player inventory
+     * @param sharonNpc the Sharon NPC — must be absent (null or far away) to succeed
+     * @param cb        achievement callback (may be null)
+     * @return result of the arson attempt
+     */
+    public VanArsonResult burnVan(Inventory inventory, NPC sharonNpc,
+                                  AchievementCallback cb) {
+        if (vanDestroyed) return VanArsonResult.VAN_DESTROYED;
+        if (sharonNpc != null) return VanArsonResult.SHARON_PRESENT;
+        if (inventory.getItemCount(Material.LIGHTER) < 1) return VanArsonResult.NO_LIGHTER;
+
+        vanDestroyed = true;
+        vanActive = false;
+
+        if (criminalRecord != null) {
+            criminalRecord.record(CrimeType.ARSON);
+            criminalRecord.record(CrimeType.CAMERA_TAMPERING);
+        }
+        if (notorietySystem != null) {
+            notorietySystem.addNotoriety(VAN_FIRE_NOTORIETY, cb);
+        }
+        if (wantedSystem != null) {
+            wantedSystem.addWantedStars(VAN_FIRE_WANTED_STARS, 0f, 0f, 0f, cb);
+        }
+        if (rumourNetwork != null) {
+            // Use a dummy NPC for seeding — supply the sharon NPC for location
+            // context; since sharon is absent use null-safe seeding via a fresh NPC
+        }
+
+        if (!speedLimitAbolishedAwarded) {
+            speedLimitAbolishedAwarded = true;
+            if (cb != null) cb.award(AchievementType.SPEED_LIMIT_ABOLISHED);
+        }
+
+        return VanArsonResult.BURNED;
+    }
+
+    // ── Mechanic 5 — Legitimate Operator Licence ─────────────────────────────
+
+    /**
+     * Player applies for an Operator Licence at the police station.
+     * Costs {@link #LICENCE_APPLICATION_COST} COIN. Requires no prior
+     * {@link CrimeType#CAMERA_TAMPERING} record.
+     *
+     * @param inventory player inventory
+     * @return result of the application
+     */
+    public LicenceApplicationResult applyForLicence(Inventory inventory) {
+        if (criminalRecord != null
+                && criminalRecord.getCount(CrimeType.CAMERA_TAMPERING) > 0) {
+            return LicenceApplicationResult.REFUSED_CRIMINAL_RECORD;
+        }
+        if (inventory.getItemCount(Material.COIN) < LICENCE_APPLICATION_COST) {
+            return LicenceApplicationResult.INSUFFICIENT_FUNDS;
+        }
+
+        inventory.removeItem(Material.COIN, LICENCE_APPLICATION_COST);
+        hasOperatorLicence = true;
+        return LicenceApplicationResult.GRANTED;
+    }
+
+    /**
+     * Player completes a legitimate operator shift beside Sharon.
+     * Earns {@link #LEGITIMATE_EARNINGS_PER_HOUR} COIN per in-game hour.
+     * Logs income to HMRCSystem. Awards {@link AchievementType#POACHER_TURNED_GAMEKEEPER}
+     * on first completion.
+     *
+     * @param hoursWorked in-game hours worked
+     * @param inventory   player inventory
+     * @param currentDay  current game day (for HMRC logging)
+     * @param cb          achievement callback (may be null)
+     * @return COIN earned (0 if no licence)
+     */
+    public int completeLegitimateShift(float hoursWorked, Inventory inventory,
+                                       int currentDay, AchievementCallback cb) {
+        if (!hasOperatorLicence) return 0;
+
+        int earned = (int) (hoursWorked * LEGITIMATE_EARNINGS_PER_HOUR);
+        if (earned > 0) {
+            inventory.addItem(Material.COIN, earned);
+            if (hmrcSystem != null) {
+                hmrcSystem.onUntaxedEarning(earned, currentDay);
+            }
+        }
+
+        if (!poacherTurnedGamekeeperAwarded) {
+            poacherTurnedGamekeeperAwarded = true;
+            if (cb != null) cb.award(AchievementType.POACHER_TURNED_GAMEKEEPER);
+        }
+
+        return earned;
+    }
+
+    // ── Queries ────────────────────────────────────────────────────────────────
+
+    /** Returns true if the van is currently deployed and active. */
+    public boolean isVanActive() { return vanActive; }
+
+    /** Returns true if Sharon is currently distracted. */
+    public boolean isSharonDistracted() { return sharonDistracted; }
+
+    /** Returns remaining distraction time in seconds. */
+    public float getDistractionTimer() { return distractionTimer; }
+
+    /** Returns the total number of cars flashed this session. */
+    public int getFlashCount() { return flashCount; }
+
+    /** Returns the number of driver tip-offs made this session. */
+    public int getTipOffCount() { return tipOffCount; }
+
+    /** Returns the total number of SD card steals. */
+    public int getSdCardSteals() { return sdCardSteals; }
+
+    /** Returns true if the camera lens is currently fogged. */
+    public boolean isLensFogged() { return lensFogged; }
+
+    /** Returns true if the van's tyres have been slashed. */
+    public boolean isTyresSlashed() { return tyresSlashed; }
+
+    /** Returns true if the van has been destroyed. */
+    public boolean isVanDestroyed() { return vanDestroyed; }
+
+    /** Returns true if the player holds a Legitimate Operator Licence. */
+    public boolean hasOperatorLicence() { return hasOperatorLicence; }
+
+    /** Returns true if Sharon has radioed police this deployment. */
+    public boolean isSharonRadioedPolice() { return sharonRadioedPolice; }
+
+    /** Returns true if the HANDWRITTEN_WARNING_SIGN_PROP is currently active. */
+    public boolean isWarningSignActive() { return warningSIgnActive; }
+
+    // ── Test-only setters ──────────────────────────────────────────────────────
+
+    /** For testing: override the distraction state. */
+    void setSharonDistractedForTesting(boolean distracted) {
+        this.sharonDistracted = distracted;
+        if (distracted) this.distractionTimer = DISTRACTION_SECONDS;
+    }
+
+    /** For testing: set the van active state directly. */
+    void setVanActiveForTesting(boolean active) {
+        this.vanActive = active;
+    }
+
+    /** For testing: set flash count directly. */
+    void setFlashCountForTesting(int count) {
+        this.flashCount = count;
+    }
+}

--- a/src/main/java/ragamuffin/entity/NPCType.java
+++ b/src/main/java/ragamuffin/entity/NPCType.java
@@ -3145,7 +3145,35 @@ public enum NPCType {
      * </ul>
      * HP: 35f, attack: 6f, cooldown: 2.0f, hostile: false (until triggered).
      */
-    DODGY_ROOFER(35f, 6f, 2.0f, false);
+    DODGY_ROOFER(35f, 6f, 2.0f, false),
+
+    // ── Issue #1416: Northfield Mobile Speed Camera Van ───────────────────────
+
+    /**
+     * CAMERA_OPERATOR_NPC — Sharon, the mobile speed camera operator.
+     * <ul>
+     *   <li>Sits in {@link ragamuffin.world.PropType#SPEED_CAMERA_VAN_PROP} reading a tabloid.</li>
+     *   <li>Active weekdays 08:00–09:30 and 15:30–17:00 near the school.</li>
+     *   <li>Photographs cars exceeding {@code SpeedCameraVanSystem.SPEED_LIMIT_MPH} within
+     *       {@code SpeedCameraVanSystem.CAMERA_RANGE_BLOCKS} blocks.</li>
+     *   <li>Can be distracted via {@link ragamuffin.world.PropType#TABLOID_RACK_PROP} for 25 seconds.</li>
+     *   <li>Radios police (WantedSystem +1) after 5 player tip-offs.</li>
+     * </ul>
+     * HP: 20f, attack: 0f, cooldown: 0f, hostile: false.
+     */
+    CAMERA_OPERATOR_NPC(20f, 0f, 0f, false),
+
+    /**
+     * SPEEDING_DRIVER_NPC — a driver approaching or passing the speed camera location.
+     * <ul>
+     *   <li>Randomly exceeds {@code SpeedCameraVanSystem.SPEED_LIMIT_MPH} (30 mph).</li>
+     *   <li>Player can wave one down (E) for a {@code SpeedCameraVanSystem.TIP_OFF_COIN_REWARD} COIN tip-off.</li>
+     *   <li>Can be sold a stolen {@link ragamuffin.building.Material#SPEED_CAMERA_SD_CARD} for 15 COIN
+     *       + {@link ragamuffin.core.RumourType#GRATEFUL_DRIVER} rumour.</li>
+     * </ul>
+     * HP: 20f, attack: 0f, cooldown: 0f, hostile: false.
+     */
+    SPEEDING_DRIVER_NPC(20f, 0f, 0f, false);
 
     private final float maxHealth;
     private final float attackDamage;   // Damage per hit to player

--- a/src/main/java/ragamuffin/ui/AchievementType.java
+++ b/src/main/java/ragamuffin/ui/AchievementType.java
@@ -6754,6 +6754,59 @@ public enum AchievementType {
         "Catalogue King",
         "Five days flogging knockoffs. Barry's not even angry. He's impressed.",
         5
+    ),
+
+    // ── Issue #1416: Northfield Mobile Speed Camera Van ───────────────────────
+
+    /**
+     * SPEED_ANGEL — warn 5 drivers about the speed camera by tipping them off (E on CAR_NPC).
+     * Awarded by SpeedCameraVanSystem when tipOffCount reaches 5.
+     */
+    SPEED_ANGEL(
+        "Speed Angel",
+        "Five drivers warned. You're practically a community service.",
+        5
+    ),
+
+    /**
+     * CANDID_CAMERA — steal the speed camera SD card 3 times.
+     * Awarded by SpeedCameraVanSystem when sdCardSteals reaches 3.
+     */
+    CANDID_CAMERA(
+        "Candid Camera",
+        "Three SD cards. Sharon keeps losing them. Someone should have a word.",
+        3
+    ),
+
+    /**
+     * FLAT_TYRE_SHARON — slash the van's tyres with a CROWBAR (+6 Notoriety, WantedSystem +1).
+     * Awarded by SpeedCameraVanSystem on the first successful tyre slash.
+     */
+    FLAT_TYRE_SHARON(
+        "Flat Tyre, Sharon",
+        "The van isn't going anywhere. Neither is Sharon. She's on hold with the AA.",
+        1
+    ),
+
+    /**
+     * SPEED_LIMIT_ABOLISHED — burn the van with a LIGHTER when Sharon is absent.
+     * Awarded by SpeedCameraVanSystem on van arson (+20 Notoriety, WantedSystem +3).
+     */
+    SPEED_LIMIT_ABOLISHED(
+        "Speed Limit Abolished",
+        "You've made your feelings about road safety policy very clear.",
+        1
+    ),
+
+    /**
+     * POACHER_TURNED_GAMEKEEPER — obtain an Operator Licence from the police station and work
+     * beside Sharon legally, earning 1 COIN/hour.
+     * Awarded by SpeedCameraVanSystem on first legitimateOperatorShift completion.
+     */
+    POACHER_TURNED_GAMEKEEPER(
+        "Poacher Turned Gamekeeper",
+        "You've gone legit. Sharon seems quietly pleased. HMRC has been notified.",
+        1
     );
 
     private final String name;

--- a/src/main/java/ragamuffin/world/PropType.java
+++ b/src/main/java/ragamuffin/world/PropType.java
@@ -3951,7 +3951,32 @@ public enum PropType {
      * Also used for CIVIC_MINDED + SNITCH rumour tip-off mechanic.
      * 1.2×1.0×0.6m; indestructible (99 hits); drops null.
      */
-    TRADING_STANDARDS_OFFICE_PROP(1.2f, 1.0f, 0.6f, 99, null);
+    TRADING_STANDARDS_OFFICE_PROP(1.2f, 1.0f, 0.6f, 99, null),
+
+    // ── Issue #1416: Northfield Mobile Speed Camera Van ───────────────────────
+
+    /**
+     * SPEED_CAMERA_VAN_PROP — Sharon's mobile speed camera GATSO van.
+     * Parked near Northfield school weekdays 08:00–09:30 and 15:30–17:00.
+     * Hold E for 4 seconds while Sharon is distracted to steal SPEED_CAMERA_SD_CARD.
+     * Can be disabled via GraffitiSystem (lens fogging), CROWBAR (tyre slash), or LIGHTER (arson).
+     * 5.5×2.2×2.0m; indestructible (99 hits); drops null.
+     */
+    SPEED_CAMERA_VAN_PROP(5.5f, 2.2f, 2.0f, 99, null),
+
+    /**
+     * HANDWRITTEN_WARNING_SIGN_PROP — a player-crafted cardboard warning sign placed on the road.
+     * Crafted from MARKER_PEN + CARDBOARD. Warns drivers automatically for 10 in-game minutes.
+     * 0.4×0.6×0.05m; 1 hit (fragile card); drops HANDWRITTEN_WARNING_SIGN.
+     */
+    HANDWRITTEN_WARNING_SIGN_PROP(0.4f, 0.6f, 0.05f, 1, ragamuffin.building.Material.HANDWRITTEN_WARNING_SIGN),
+
+    /**
+     * TABLOID_RACK_PROP — a tabloid newspaper rack near Sharon's van.
+     * Player interacts (E) to distract Sharon for 25 in-game seconds.
+     * 0.3×1.2×0.3m; indestructible (99 hits); drops null.
+     */
+    TABLOID_RACK_PROP(0.3f, 1.2f, 0.3f, 99, null);
 
     // ─────────────────────────────────────────────────────────────────────────
     // Issue #719: Collision and destructibility data


### PR DESCRIPTION
## Summary
Automated fix for issue #1416.

## Changes
- Fix #1416: automated fix

Closes #1416