### PR TITLE
Fix #1459: Add Northfield Church Hall Jumble Sale — Dot's Tables, the Premium Rummage & the Bring-and-Buy Fiddle

### DIFF
--- a/src/main/java/ragamuffin/building/Material.java
+++ b/src/main/java/ragamuffin/building/Material.java
@@ -6826,7 +6826,58 @@ public enum Material {
      *   <li>Steal the board (7 HARD hits): service cut 5 days, Notoriety +3, Vibes −5.</li>
      * </ul>
      */
-    PETITION_BOARD("Petition Board");
+    PETITION_BOARD("Petition Board"),
+
+    // ── Issue #1459: Northfield Church Hall Jumble Sale ───────────────────────
+
+    /**
+     * JUMBLE_ENTRY_TICKET — paper entry ticket from Dot for 1 COIN.
+     * Required to enter the Community Centre during jumble sale (09:00–13:00).
+     */
+    JUMBLE_ENTRY_TICKET("Jumble Sale Entry Ticket"),
+
+    /**
+     * JUMBLE_ORNAMENT — china ornament from the premium table (table 3).
+     * Fence value: 3 COIN. Item base price: 2 COIN.
+     */
+    JUMBLE_ORNAMENT("Ornament"),
+
+    /**
+     * JUMBLE_CLOCK — old mantle clock from the premium table.
+     * Fence value: 5 COIN. Item base price: 3 COIN.
+     */
+    JUMBLE_CLOCK("Old Clock"),
+
+    /**
+     * JUMBLE_BOOK_LOT — bundle of paperbacks from the premium table.
+     * Fence value: 2 COIN. Item base price: 1 COIN.
+     */
+    JUMBLE_BOOK_LOT("Book Bundle"),
+
+    /**
+     * JUMBLE_CASSETTE — cassette tape from the tat tables (13–15).
+     * Fence value: 0 COIN. Item base price: 1 COIN.
+     */
+    JUMBLE_CASSETTE("Cassette Tape"),
+
+    /**
+     * JUMBLE_VHS_TAPE — VHS tape from the tat tables.
+     * Fence value: 1 COIN. Item base price: 1 COIN.
+     */
+    JUMBLE_VHS_TAPE("VHS Tape"),
+
+    /**
+     * JUMBLE_COAT — second-hand coat from the tat tables.
+     * Confers +15 warmth when equipped; reduces volunteer detection 20%.
+     * Item base price: 2 COIN.
+     */
+    JUMBLE_COAT("Second-Hand Coat"),
+
+    /**
+     * JUMBLE_RECEIPT_PROP — handwritten receipt from Dot's bring-and-buy table.
+     * Valid proof of legitimate purchase; clears the STOLEN flag from a donated item.
+     */
+    JUMBLE_RECEIPT_PROP("Jumble Receipt");
 
     private final String displayName;
 

--- a/src/main/java/ragamuffin/core/CriminalRecord.java
+++ b/src/main/java/ragamuffin/core/CriminalRecord.java
@@ -1303,7 +1303,29 @@ public class CriminalRecord {
          * from the Raj Mahal kitchen while Bashir has line-of-sight.
          * Penalty: Notoriety +3, chase triggered, police called after 10 seconds.
          */
-        RESTAURANT_THEFT("Theft from a restaurant kitchen");
+        RESTAURANT_THEFT("Theft from a restaurant kitchen"),
+
+        // ── Issue #1459: Northfield Church Hall Jumble Sale ───────────────────
+
+        /**
+         * JUMBLE_SHOPLIFTING — recorded when caught pocketing an item at Dot's jumble sale.
+         * Penalty: Notoriety +4, ejected from hall; JUMBLE_THIEF rumour seeded.
+         */
+        JUMBLE_SHOPLIFTING("Shoplifting (jumble sale)"),
+
+        /**
+         * JUMBLE_BREAKING_AND_ENTERING — recorded when forcing the back window of the
+         * Community Centre during the pre-opening window (08:45–09:00).
+         * Penalty: Notoriety +5; WantedSystem +1 if CCTV active.
+         */
+        JUMBLE_BREAKING_AND_ENTERING("Breaking and entering (community centre)"),
+
+        /**
+         * JUMBLE_HANDLING_STOLEN_GOODS — recorded when a volunteer recognises stolen
+         * items on the player's rented stall (Notoriety ≥ 40, 20% scrutiny chance).
+         * Penalty: WantedSystem +1.
+         */
+        JUMBLE_HANDLING_STOLEN_GOODS("Handling stolen goods (jumble sale stall)");
 
         private final String displayName;
 

--- a/src/main/java/ragamuffin/core/RumourType.java
+++ b/src/main/java/ragamuffin/core/RumourType.java
@@ -1661,5 +1661,22 @@ public enum RumourType {
     /** "They've boarded up the Crown for good. Flats going in. It's a disgrace."
      * — seeded by SaveOurPubSystem on a Developer Win at the committee vote.
      * Spreads via PUBLIC and PENSIONER NPCs. */
-    CROWN_ANCHOR_GONE;
+    CROWN_ANCHOR_GONE,
+
+    // ── Issue #1459: Northfield Church Hall Jumble Sale ───────────────────────
+
+    /** "Some pensioner elbowed me out the way at the jumble sale. Did me nut in."
+     * — seeded by JumbleSaleSystem when a PENSIONER beats the player to an item.
+     * Spreads via PUBLIC and PENSIONER NPCs. */
+    JUMBLE_QUEUE_JUMPED,
+
+    /** "Someone got caught pocketing stuff at Dot's jumble sale. Got marched out by a volunteer in a tabard."
+     * — seeded by JumbleSaleSystem on shoplifting detection.
+     * Spreads via PUBLIC and PENSIONER NPCs. */
+    JUMBLE_THIEF,
+
+    /** "Someone broke into the community centre before the jumble sale even opened. The cheek of it."
+     * — seeded by JumbleSaleSystem on pre-opening break-in; also triggers NewspaperSystem headline.
+     * Spreads via PUBLIC and PENSIONER NPCs. */
+    JUMBLE_BREAK_IN;
 }

--- a/src/main/java/ragamuffin/entity/NPCType.java
+++ b/src/main/java/ragamuffin/entity/NPCType.java
@@ -3322,7 +3322,26 @@ public enum NPCType {
      * the RARE_BOOK_SHELF_PROP theft (3s hold-E). Sits in LIBRARY_REGULAR_SEAT_PROP.
      * HP: 50, attack: 0, cooldown: 0, not hostile.
      */
-    LIBRARY_REGULAR(50f, 0f, 0f, false);
+    LIBRARY_REGULAR(50f, 0f, 0f, false),
+
+    // ── Issue #1459: Northfield Church Hall Jumble Sale ───────────────────────
+
+    /**
+     * Dot — organiser of the monthly jumble sale at the Community Centre.
+     * Manages the entrance desk, tea urn, and fifteen tables of second-hand goods.
+     * Runs the entry-ticket desk (09:00–09:15) and the bring-and-buy desk.
+     * Becomes HOSTILE if shoplifting is detected; IRRITATED on failed haggle (120s).
+     * HP: 60, attack: 0, cooldown: 0, not hostile.
+     */
+    JUMBLE_SALE_ORGANISER(60f, 0f, 0f, false),
+
+    /**
+     * Volunteer helper at Dot's jumble sale — one of three patrol volunteers who each
+     * cover two tables apiece. Detects shoplifting via line-of-sight checks.
+     * Becomes distracted by TEA_CUP for 20 real seconds. Wears a tabard.
+     * HP: 40, attack: 0, cooldown: 0, not hostile.
+     */
+    JUMBLE_SALE_VOLUNTEER(40f, 0f, 0f, false);
 
     private final float maxHealth;
     private final float attackDamage;   // Damage per hit to player

--- a/src/main/java/ragamuffin/ui/AchievementType.java
+++ b/src/main/java/ragamuffin/ui/AchievementType.java
@@ -7206,6 +7206,62 @@ public enum AchievementType {
         "People's Pub",
         "Your squat lock-ins convinced the council to save the Crown & Anchor.",
         1
+    ),
+
+    // ── Issue #1459: Northfield Church Hall Jumble Sale ───────────────────────
+
+    /**
+     * JUMBLE_REGULAR — attend 3 consecutive monthly jumble sales.
+     */
+    JUMBLE_REGULAR(
+        "Jumble Regular",
+        "Attended three consecutive monthly jumble sales. A creature of routine.",
+        3
+    ),
+
+    /**
+     * BARGAIN_HUNTER_JUMBLE — purchase 5 items in a single jumble sale.
+     */
+    BARGAIN_HUNTER_JUMBLE(
+        "Bargain Hunter",
+        "Bought five items in a single jumble sale. Dot will be pleased.",
+        5
+    ),
+
+    /**
+     * FIVE_FINGER_JUMBLE — pocket 3 items at the jumble sale without detection.
+     */
+    FIVE_FINGER_JUMBLE(
+        "Five Finger Discount",
+        "Pocketed three items at the jumble sale without being spotted. Mind the volunteers.",
+        3
+    ),
+
+    /**
+     * MARKET_TRADER_JUMBLE — earn 15 COIN from a single stall session.
+     */
+    MARKET_TRADER_JUMBLE(
+        "Market Trader",
+        "Earned 15 COIN from your stall at a single jumble sale. Entrepreneur.",
+        15
+    ),
+
+    /**
+     * EARLY_BIRD_JUMBLE — pocket 4+ items during pre-opening break-in window.
+     */
+    EARLY_BIRD_JUMBLE(
+        "Early Bird",
+        "Broke into the community centre and pocketed four items before the doors opened. Shameless.",
+        4
+    ),
+
+    /**
+     * THROUGH_THE_BOOKS — launder 3 stolen items through the bring-and-buy in one session.
+     */
+    THROUGH_THE_BOOKS(
+        "Through the Books",
+        "Laundered three stolen items through the bring-and-buy. Very professional.",
+        3
     );
 
     private final String name;


### PR DESCRIPTION
## Summary
Automated fix for issue #1459.

## Changes
- Fix #1459: automated fix

Closes #1459