### PR TITLE
Fix #1469: Add Northfield Second-Hand Record Shop — Spin City, the Crate Dig & the Rare Pressings Racket

### DIFF
--- a/src/main/java/ragamuffin/building/Material.java
+++ b/src/main/java/ragamuffin/building/Material.java
@@ -6895,7 +6895,26 @@ public enum Material {
      * Can be used as evidence at the COUNCIL_OFFICE to trigger the Trading Standards sting.
      * Holding it as evidence earns a 5 COIN whistleblower reward.
      */
-    BLESSED_WATER_BOTTLE("Blessed Water Bottle");
+    BLESSED_WATER_BOTTLE("Blessed Water Bottle"),
+
+    // ── Issue #1469: Northfield Second-Hand Record Shop ───────────────────────
+
+    /**
+     * RARE_PRESSING — a genuine rare vinyl pressing from a RECORD_SHELF_PROP (12% crate-dig chance).
+     * Sell price: 6 COIN to Clive; 12 COIN to Trevor if it matches his genre.
+     * Broadcast on TRANSMITTER_PROP draws +6 LISTENER NPCs and grants Vibes +2 town-wide.
+     * Fence value: 4 COIN.
+     */
+    RARE_PRESSING("Rare Pressing"),
+
+    /**
+     * FAKE_RARE_LABEL — a forged rare-pressing label, crafted from PRINTER_PAPER + INK_BOTTLE
+     * at the InternetCafe. Apply to a standard VINYL_RECORD to pass it off as a RARE_PRESSING.
+     * Clive catches it 35% of the time (Notoriety +6, CrimeType.FRAUD, banned for the day).
+     * Trevor catches it 50% of the time (HOSTILE, TRADING_SCAM rumour, skips 3 Wednesdays).
+     * Successfully fool Clive 3 times → CLIVE_KNOWS_NOTHING achievement.
+     */
+    FAKE_RARE_LABEL("Fake Rare Label");
 
     private final String displayName;
 
@@ -8381,6 +8400,18 @@ public enum Material {
                                                     0.15f, 0.42f, 0.72f); // Blue stamp
             case PETITION_BOARD:          return cs(0.72f, 0.55f, 0.30f, // Brown clipboard
                                                     0.88f, 0.92f, 0.88f); // White paper
+
+            // Issue #1461: Northfield Street Preacher
+            case MEGAPHONE:               return cs(0.88f, 0.72f, 0.10f, // Yellow megaphone body
+                                                    0.48f, 0.48f, 0.52f); // Grey handle
+            case BLESSED_WATER_BOTTLE:    return cs(0.62f, 0.82f, 0.92f, // Light blue bottle
+                                                    0.88f, 0.92f, 0.88f); // White label
+
+            // Issue #1469: Northfield Second-Hand Record Shop
+            case RARE_PRESSING:           return cs(0.10f, 0.10f, 0.10f, // Black vinyl
+                                                    0.88f, 0.72f, 0.10f); // Gold label
+            case FAKE_RARE_LABEL:         return cs(0.88f, 0.72f, 0.10f, // Gold foil
+                                                    0.88f, 0.92f, 0.88f); // White paper backing
 
             default:             return c(0.5f, 0.5f, 0.5f);
         }

--- a/src/main/java/ragamuffin/entity/NPCType.java
+++ b/src/main/java/ragamuffin/entity/NPCType.java
@@ -3341,7 +3341,27 @@ public enum NPCType {
      * Becomes distracted by TEA_CUP for 20 real seconds. Wears a tabard.
      * HP: 40, attack: 0, cooldown: 0, not hostile.
      */
-    JUMBLE_SALE_VOLUNTEER(40f, 0f, 0f, false);
+    JUMBLE_SALE_VOLUNTEER(40f, 0f, 0f, false),
+
+    // ── Issue #1469: Northfield Second-Hand Record Shop ───────────────────────
+
+    /**
+     * Clive — proprietor of Spin City Records, a cramped vinyl emporium.
+     * Anchored behind the counter; patrols a 4-block route when the shop is open.
+     * Catches FAKE_RARE_LABEL fraud 35% of the time (Notoriety +6, bans player for the day).
+     * Visits CHARITY_SHOP as a customer every Thursday 09:00–10:00.
+     * HP: 60, attack: 0, cooldown: 0, not hostile.
+     */
+    RECORD_SHOP_OWNER(60f, 0f, 0f, false),
+
+    /**
+     * Trevor — an obsessive vinyl collector who visits Spin City Records every Wednesday
+     * 13:00–16:00, hunting a randomly assigned genre. Has a 30-COIN session budget.
+     * Catches FAKE_RARE_LABEL fraud 50% of the time (becomes HOSTILE, seeds
+     * TRADING_SCAM rumour, skips 3 Wednesdays).
+     * HP: 55, attack: 0, cooldown: 0, not hostile.
+     */
+    RECORD_COLLECTOR(55f, 0f, 0f, false);
 
     private final float maxHealth;
     private final float attackDamage;   // Damage per hit to player

--- a/src/main/java/ragamuffin/world/LandmarkType.java
+++ b/src/main/java/ragamuffin/world/LandmarkType.java
@@ -783,7 +783,17 @@ public enum LandmarkType {
      * (BALTI_HOUSE_DOOR_PROP), and back door (BALTI_BACK_DOOR_PROP).
      * Managed by BaltiHouseSystem.
      */
-    BALTI_HOUSE;
+    BALTI_HOUSE,
+
+    // ── Issue #1469: Northfield Second-Hand Record Shop ───────────────────────
+
+    /**
+     * RECORD_SHOP — Spin City Records, a cramped vinyl emporium on the high street.
+     * Operated by Clive (RECORD_SHOP_OWNER NPC). Open Tue–Sat 10:00–17:30.
+     * Features RECORD_SHELF_PROPs for crate digging and a dedicated trade economy
+     * for VINYL_RECORD and RARE_PRESSING items. Managed by RecordShopSystem.
+     */
+    RECORD_SHOP;
 
     /**
      * Returns the display name shown on the building's sign.
@@ -892,6 +902,7 @@ public enum LandmarkType {
             case CYCLE_SHOP:            return "Dave's Cycle Centre";
             case WELCOME_SIGN:          return "Welcome to Northfield";
             case BALTI_HOUSE:           return "The Raj Mahal";
+            case RECORD_SHOP:           return "Spin City Records";
             default:                    return null; // No sign for parks, houses, etc.
         }
     }

--- a/src/main/java/ragamuffin/world/PropType.java
+++ b/src/main/java/ragamuffin/world/PropType.java
@@ -4338,7 +4338,18 @@ public enum PropType {
      * Area", "Forklift Operating") on a warehouse wall.
      * Purely decorative. Destroyed by 1 punch; yields nothing.
      */
-    SAFETY_SIGN(0.60f, 0.60f, 0.02f, 1, null);
+    SAFETY_SIGN(0.60f, 0.60f, 0.02f, 1, null),
+
+    // ── Issue #1469: Northfield Second-Hand Record Shop ───────────────────────
+
+    /**
+     * RECORD_SHELF_PROP — a wooden crate-and-shelf unit packed with vinyl records
+     * inside Spin City Records. Player can browse (E) to buy a VINYL_RECORD for 2 COIN,
+     * or hold E for 6 seconds to crate-dig (12% chance of RARE_PRESSING at standard price,
+     * before Clive spots them). Three to five units line the walls of the shop.
+     * Destroyed by 4 punches; drops a VINYL_RECORD.
+     */
+    RECORD_SHELF_PROP(0.80f, 1.60f, 0.40f, 4, Material.VINYL_RECORD);
 
     // ─────────────────────────────────────────────────────────────────────────
     // Issue #719: Collision and destructibility data


### PR DESCRIPTION
## Summary
Automated fix for issue #1469.

## Changes
- Fix #1469: automated fix

Closes #1469