### PR TITLE
Fix #1471: Add Northfield Closing-Down Sale — Dave's Everything Must Go, the Shill Shift & the Liquidation Heist

### DIFF
--- a/src/main/java/ragamuffin/building/Material.java
+++ b/src/main/java/ragamuffin/building/Material.java
@@ -6914,7 +6914,28 @@ public enum Material {
      * Trevor catches it 50% of the time (HOSTILE, TRADING_SCAM rumour, skips 3 Wednesdays).
      * Successfully fool Clive 3 times → CLIVE_KNOWS_NOTHING achievement.
      */
-    FAKE_RARE_LABEL("Fake Rare Label");
+    FAKE_RARE_LABEL("Fake Rare Label"),
+
+    // ── Issue #1471: Northfield Closing-Down Sale — Dave's Everything Must Go ──
+
+    /**
+     * KNOCKOFF_ELECTRONIC — a generic knockoff electronic item (hairdryer, extension
+     * lead, phone charger, telly, laptop, or kettle) sold at Dave's perpetual
+     * closing-down sale at "70% off" prices that are actually above RRP.
+     * Fence value: 1–4 COIN. Can be used as a component in crafting recipes
+     * (e.g. 3× KNOCKOFF_ELECTRONIC → 1 DISTRACTION_DEVICE at a workbench).
+     * The KNOCKOFF_LAPTOP variant can be traded to INTERNET_CAFE_OWNER for
+     * INTERNET_CAFE_DISCOUNT_CARD (2 free internet sessions).
+     */
+    KNOCKOFF_ELECTRONIC("Knockoff Electronic"),
+
+    /**
+     * BRAND_NAME_TELLY — the one item in Dave's life that is actually worth
+     * something: a genuine brand-name television accidentally stocked in the
+     * liquidation delivery. Fence value: 20 COIN. Can be placed as a decorative
+     * prop in a player-owned squat, raising Squat Comfort by 5.
+     */
+    BRAND_NAME_TELLY("Brand Name Telly");
 
     private final String displayName;
 
@@ -8412,6 +8433,12 @@ public enum Material {
                                                     0.88f, 0.72f, 0.10f); // Gold label
             case FAKE_RARE_LABEL:         return cs(0.88f, 0.72f, 0.10f, // Gold foil
                                                     0.88f, 0.92f, 0.88f); // White paper backing
+
+            // Issue #1471: Northfield Closing-Down Sale
+            case KNOCKOFF_ELECTRONIC:     return cs(0.35f, 0.35f, 0.40f, // Grey plastic casing
+                                                    0.88f, 0.15f, 0.12f); // Red "SALE" sticker
+            case BRAND_NAME_TELLY:        return cs(0.12f, 0.12f, 0.15f, // Black TV body
+                                                    0.55f, 0.78f, 0.92f); // Blue screen glow
 
             default:             return c(0.5f, 0.5f, 0.5f);
         }

--- a/src/main/java/ragamuffin/core/CriminalRecord.java
+++ b/src/main/java/ragamuffin/core/CriminalRecord.java
@@ -1333,7 +1333,26 @@ public class CriminalRecord {
          * BREACH_OF_PEACE — recorded when the player heckles Brother Gary and noise
          * level reaches ≥ 7, summoning a PCSO. Penalty: WantedSystem +1.
          */
-        BREACH_OF_PEACE("Breach of the peace (heckling)");
+        BREACH_OF_PEACE("Breach of the peace (heckling)"),
+
+        // ── Issue #1471: Northfield Closing-Down Sale — Dave's Everything Must Go ──
+
+        /**
+         * Recorded when the player loses an argument with Gary (COUNCIL_ENFORCEMENT_OFFICER)
+         * while doing shill work for Dave's closing-down sale (ClosingDownSaleSystem).
+         * Also recorded on a failed GARY_ARGUE outcome during the Shill Shift.
+         * Penalty: WantedSystem +1 star, Notoriety +2, shill shift ends immediately.
+         */
+        MISLEADING_ADVERTISING("Misleading advertising (shill for fake closing-down sale)"),
+
+        /**
+         * Recorded when the player submits a Trading Standards tip-off against Dave's
+         * closing-down sale having previously worked as a shill for him.
+         * The TS officer notes the conflict of interest and issues a mild caution.
+         * Penalty: no additional Notoriety; reward is halved to
+         * {@link ragamuffin.core.ClosingDownSaleSystem#TS_CONFLICT_REWARD_COINS}.
+         */
+        CAUTION("Caution (conflict of interest — TS tip-off after shill work)");
 
         private final String displayName;
 

--- a/src/main/java/ragamuffin/entity/NPCType.java
+++ b/src/main/java/ragamuffin/entity/NPCType.java
@@ -3361,7 +3361,21 @@ public enum NPCType {
      * TRADING_SCAM rumour, skips 3 Wednesdays).
      * HP: 55, attack: 0, cooldown: 0, not hostile.
      */
-    RECORD_COLLECTOR(55f, 0f, 0f, false);
+    RECORD_COLLECTOR(55f, 0f, 0f, false),
+
+    // ── Issue #1471: Northfield Closing-Down Sale — Dave's Everything Must Go ──
+
+    /**
+     * CLOSING_DOWN_DAVE — Dave, mid-50s, permanent look of weary optimism,
+     * always has a price gun in his breast pocket. Runs Dave's Electronics &amp;
+     * Electrical, a perpetual fake closing-down sale on the high street.
+     * Passive behind the counter; becomes HOSTILE if player is caught in the
+     * stockroom. Shares one free {@link ragamuffin.core.RumourType#LOCAL_GOSSIP}
+     * per conversation (always about his ongoing "liquidation").
+     * Refuses service to players with Notoriety &ge; 50 or carrying a POLICE_BADGE.
+     * HP: 50, attack: 0, cooldown: 0, not hostile by default.
+     */
+    CLOSING_DOWN_DAVE(50f, 0f, 0f, false);
 
     private final float maxHealth;
     private final float attackDamage;   // Damage per hit to player

--- a/src/main/java/ragamuffin/ui/AchievementType.java
+++ b/src/main/java/ragamuffin/ui/AchievementType.java
@@ -7347,6 +7347,49 @@ public enum AchievementType {
         "By the Book",
         "Reported the dodgy blessed water seller to Trading Standards with a clean record. Very civic-minded.",
         1
+    ),
+
+    // ── Issue #1471: Northfield Closing-Down Sale — Dave's Everything Must Go ──
+
+    /**
+     * HUMAN_SANDWICH_BOARD — complete 5 shill shifts for Dave without Gary
+     * (COUNCIL_ENFORCEMENT_OFFICER) catching you. You've got the gift of the gab.
+     */
+    HUMAN_SANDWICH_BOARD(
+        "Human Sandwich Board",
+        "Completed 5 shill shifts for Dave without Trading Standards catching you. You've got the gift of the gab.",
+        5
+    ),
+
+    /**
+     * TRADING_STANDARDS_HERO — report Dave's perpetual closing-down sale to
+     * Trading Standards after witnessing 3 phase transitions.
+     */
+    TRADING_STANDARDS_HERO(
+        "Trading Standards Hero",
+        "Reported Dave's perpetual closing-down sale. He was back open on Monday.",
+        1
+    ),
+
+    /**
+     * EVERYTHING_MUST_GO — loot Dave's stockroom on the GENUINELY_CLOSING_TOMORROW
+     * liquidation day. He would've wanted it this way.
+     */
+    EVERYTHING_MUST_GO(
+        "Everything Must Go",
+        "Looted Dave's stockroom on liquidation day. He would've wanted it this way.",
+        1
+    ),
+
+    /**
+     * NEVER_CLOSING_DOWN — witness all four phases of Dave's closing-down cycle
+     * (FINAL_WEEK → LAST_FEW_DAYS → GENUINELY_CLOSING_TOMORROW →
+     * REOPENED_UNDER_NEW_MANAGEMENT). You've outlasted the signs.
+     */
+    NEVER_CLOSING_DOWN(
+        "Never Closing Down",
+        "Witnessed all four phases of Dave's closing-down cycle. You've outlasted the signs.",
+        4
     );
 
     private final String name;

--- a/src/main/java/ragamuffin/world/LandmarkType.java
+++ b/src/main/java/ragamuffin/world/LandmarkType.java
@@ -793,7 +793,17 @@ public enum LandmarkType {
      * Features RECORD_SHELF_PROPs for crate digging and a dedicated trade economy
      * for VINYL_RECORD and RARE_PRESSING items. Managed by RecordShopSystem.
      */
-    RECORD_SHOP;
+    RECORD_SHOP,
+
+    // ── Issue #1471: Northfield Closing-Down Sale — Dave's Everything Must Go ──
+
+    /**
+     * CLOSING_DOWN_SHOP — Dave's Electronics &amp; Electrical. An 8×6×3 shopfront
+     * on the high street, perpetually "closing down" for three years. Always has
+     * a yellowed CLOSING_DOWN_SIGN_PROP A-frame in the window. Adjacent to
+     * PAVEMENT blocks. Managed by ClosingDownSaleSystem.
+     */
+    CLOSING_DOWN_SHOP;
 
     /**
      * Returns the display name shown on the building's sign.
@@ -903,6 +913,7 @@ public enum LandmarkType {
             case WELCOME_SIGN:          return "Welcome to Northfield";
             case BALTI_HOUSE:           return "The Raj Mahal";
             case RECORD_SHOP:           return "Spin City Records";
+            case CLOSING_DOWN_SHOP:     return "Dave's Electronics & Electrical — FINAL WEEK";
             default:                    return null; // No sign for parks, houses, etc.
         }
     }

--- a/src/main/java/ragamuffin/world/PropType.java
+++ b/src/main/java/ragamuffin/world/PropType.java
@@ -4349,7 +4349,28 @@ public enum PropType {
      * before Clive spots them). Three to five units line the walls of the shop.
      * Destroyed by 4 punches; drops a VINYL_RECORD.
      */
-    RECORD_SHELF_PROP(0.80f, 1.60f, 0.40f, 4, Material.VINYL_RECORD);
+    RECORD_SHELF_PROP(0.80f, 1.60f, 0.40f, 4, Material.VINYL_RECORD),
+
+    // ── Issue #1471: Northfield Closing-Down Sale — Dave's Everything Must Go ──
+
+    /**
+     * CLOSING_DOWN_SIGN_PROP — the yellowed A-frame sign outside Dave's Electronics
+     * &amp; Electrical. Press E (during trading hours, player alone) to read the current
+     * phase text ("FINAL WEEK — EVERYTHING MUST GO — UP TO 70% OFF" etc.).
+     * Indestructible. Changes text every {@link ragamuffin.core.ClosingDownSaleSystem#PHASE_CYCLE_DAYS} days.
+     */
+    CLOSING_DOWN_SIGN_PROP(0.60f, 1.20f, 0.05f, Integer.MAX_VALUE, null),
+
+    /**
+     * STOCKROOM_CRATE_PROP — a battered cardboard packing crate in the back of
+     * Dave's shop. Hold E for {@link ragamuffin.core.ClosingDownSaleSystem#CRATE_LOOT_HOLD_SECONDS}
+     * seconds to loot during the heist window on GENUINELY_CLOSING_TOMORROW day.
+     * Contains {@link ragamuffin.core.ClosingDownSaleSystem#LIQUIDATION_LOOT_COUNT} knockoffs
+     * plus 1 guaranteed {@link Material#BRAND_NAME_TELLY}.
+     * Disappears after looting; reappears on the next GENUINELY_CLOSING_TOMORROW day.
+     * Indestructible while stocked; drops nothing.
+     */
+    STOCKROOM_CRATE_PROP(0.80f, 0.80f, 0.80f, Integer.MAX_VALUE, null);
 
     // ─────────────────────────────────────────────────────────────────────────
     // Issue #719: Collision and destructibility data


### PR DESCRIPTION
## Summary
Automated fix for issue #1471.

## Changes
- Fix #1471: automated fix

Closes #1471