### PR TITLE
Fix #1481: Add Northfield Driving Test Centre — Keith's Nervous Pass, the Cancellation Scalper & the Bent Examiner

### DIFF
--- a/src/main/java/ragamuffin/building/Material.java
+++ b/src/main/java/ragamuffin/building/Material.java
@@ -7068,7 +7068,58 @@ public enum Material {
      * If inspected, reveals it was wired from a public defibrillator cabinet.
      * Tooltip: "Extension lead. Very well-made, actually."
      */
-    REWIRED_EXTENSION_LEAD("Rewired Extension Lead");
+    REWIRED_EXTENSION_LEAD("Rewired Extension Lead"),
+
+    // ── Issue #1481: Northfield Driving Test Centre ───────────────────────────
+
+    /**
+     * TEST_APPOINTMENT_CARD — official DVSA test appointment card issued by Sandra
+     * at the reception desk on booking. Costs 5 COIN; slot is 3 in-game days out.
+     * Present to Keith to begin the practical test. Single-use.
+     * Tooltip: "Driving test appointment. Don't be late."
+     */
+    TEST_APPOINTMENT_CARD("Test Appointment Card"),
+
+    /**
+     * FORGED_APPOINTMENT_CARD — crafted at the InternetCafeSystem using BLANK_CARD
+     * + INK_CARTRIDGE. Functions identically to TEST_APPOINTMENT_CARD but carries a
+     * 25% detection chance; caught → WantedSystem +1, CrimeType.IDENTITY_FRAUD.
+     * Tooltip: "Looks official. Probably fine."
+     */
+    FORGED_APPOINTMENT_CARD("Forged Appointment Card"),
+
+    /**
+     * CANCELLED_SLOT_VOUCHER — issued by Sandra when the player cancels a booking
+     * (3 COIN partial refund). Sell to Wayne (TEST_SLOT_SCALPER) for 6 COIN, or
+     * directly to LEARNER_DRIVER NPCs for 10 COIN.
+     * Tooltip: "Someone's cancelled slot. Worth more to the right person."
+     */
+    CANCELLED_SLOT_VOUCHER("Cancelled Slot Voucher"),
+
+    /**
+     * INVALID_LICENCE — the player's DRIVING_LICENCE after it has been invalidated
+     * by the DVSA inspector following a bribed-pass discovery. Cannot be used to
+     * reduce police-stop chance. Can be shown to the solicitor for a refund dispute.
+     * Tooltip: "Driving licence — INVALID. Signed by the DVSA."
+     */
+    INVALID_LICENCE("Invalid Licence"),
+
+    /**
+     * FAKE_PROVISIONAL_LICENCE — crafted from BLANK_CARD + LAMINATOR_POUCH +
+     * STOLEN_PASSPORT_PHOTO. Allows booking a test under a false identity.
+     * Detected at 25% chance by Sandra; caught → WantedSystem +1, IDENTITY_FRAUD.
+     * Tooltip: "Fake provisional. The laminate is a bit bubbly."
+     */
+    FAKE_PROVISIONAL_LICENCE("Fake Provisional Licence"),
+
+    /**
+     * L_PLATE_PROPS — a pair of magnetic L-plates sold at the corner shop for 1 COIN.
+     * Equip to drive unlicensed; reduces police stop chance by 30%.
+     * Remove while being watched → CrimeType.DRIVING_UNINSURED + Notoriety +3.
+     * Can be stuck on NPC cars (2-second E hold) as a prank.
+     * Tooltip: "Learner plates. Surprisingly effective."
+     */
+    L_PLATE_PROPS("L-Plate Props");
 
     private final String displayName;
 

--- a/src/main/java/ragamuffin/core/RumourType.java
+++ b/src/main/java/ragamuffin/core/RumourType.java
@@ -1729,5 +1729,28 @@ public enum RumourType {
     /** "The defibrillator cabinet's been raided — someone nicked the cables. They're actually dangerous."
      * — seeded by DefibrillatorSystem when a CARDIAC_VICTIM dies because the copper cable was missing.
      * Spreads via PUBLIC, PENSIONER, COUNCIL_WORKER, and POLICE NPCs; raises Notoriety +15. */
-    DEFIB_SABOTAGED;
+    DEFIB_SABOTAGED,
+
+    // ── Issue #1481: Northfield Driving Test Centre ───────────────────────────
+
+    /** "That examiner at the test centre — Keith — he's taking backhanders. Brown envelope,
+     * back door, half-five. Everyone knows."
+     * — seeded by DrivingTestSystem when the player tips off the DVSA via
+     * TEST_CENTRE_PHONE_BOX_PROP. Spreads via PUBLIC, PENSIONER, and BARMAN NPCs;
+     * triggers the DVSA inspector's early visit next morning at 09:30. */
+    BENT_EXAMINER_RUMOUR,
+
+    /** "Some lad outside the test centre flogging cancelled slots. Ten quid a go.
+     * Absolute liberty."
+     * — seeded by DrivingTestSystem after 3 CANCELLED_SLOT_VOUCHER sales to LEARNER_DRIVER
+     * NPCs in a single in-game day. Spreads via PUBLIC and PENSIONER NPCs;
+     * triggers WantedSystem +1. */
+    SLOT_TOUT_RUMOUR,
+
+    /** "Someone stuck L-plates on Dave's motor while he was in the chippy.
+     * He drove all the way to his mum's before he noticed."
+     * — seeded by DrivingTestSystem when the player successfully sticks L_PLATE_PROPS
+     * on a civilian NPC's car. Spreads via PUBLIC and BARMAN NPCs;
+     * awards AchievementType.LEARNER_LEGS. */
+    L_PLATE_PRANK_RUMOUR;
 }

--- a/src/main/java/ragamuffin/entity/NPCType.java
+++ b/src/main/java/ragamuffin/entity/NPCType.java
@@ -3437,7 +3437,38 @@ public enum NPCType {
      * pins a CPR_TRAINING_FLYER. Pay 5 COIN each; expect 60 seconds of instruction.
      * HP: 20, attack: 0, cooldown: 0, not hostile.
      */
-    CPR_STUDENT(20f, 0f, 0f, false);
+    CPR_STUDENT(20f, 0f, 0f, false),
+
+    // ── Issue #1481: Northfield Driving Test Centre ───────────────────────────
+
+    /**
+     * TEST_CENTRE_RECEPTIONIST — Sandra, the DVSA reception desk clerk at the
+     * Driving Test Centre. Stationary at TEST_CENTRE_DESK_PROP during 09:00–17:00
+     * Mon–Fri. Press E to book a test (5 COIN) or cancel an existing booking.
+     */
+    TEST_CENTRE_RECEPTIONIST(30f, 0f, 0f, false),
+
+    /**
+     * DRIVING_EXAMINER — Keith, the DVSA driving examiner. Conducts the practical
+     * test route (BattleBarMiniGame, MEDIUM difficulty, 8 steps). Lingers at
+     * TEST_CENTRE_REAR_EXIT_PROP 17:00–17:30 after a test failure (bribery window).
+     * Becomes hostile after 3 test failures by the same player.
+     */
+    DRIVING_EXAMINER(40f, 6f, 1.5f, false),
+
+    /**
+     * TEST_SLOT_SCALPER — Wayne, a tout who loiters outside the Driving Test Centre.
+     * Sells 1-day advance slots for 8 COIN (15% fraud-detection risk). Buys
+     * CANCELLED_SLOT_VOUCHERs from the player for 6 COIN and resells to learners.
+     */
+    TEST_SLOT_SCALPER(25f, 0f, 0f, false),
+
+    /**
+     * LEARNER_DRIVER — nervous learners who congregate outside the test centre
+     * 08:30–09:00 and 15:00–16:00. Will buy CANCELLED_SLOT_VOUCHERs for 10 COIN.
+     * Press E to offer a slot; 3 sales in one day triggers SLOT_SHARK achievement.
+     */
+    LEARNER_DRIVER(20f, 0f, 0f, false);
 
     private final float maxHealth;
     private final float attackDamage;   // Damage per hit to player

--- a/src/main/java/ragamuffin/world/LandmarkType.java
+++ b/src/main/java/ragamuffin/world/LandmarkType.java
@@ -803,7 +803,19 @@ public enum LandmarkType {
      * a yellowed CLOSING_DOWN_SIGN_PROP A-frame in the window. Adjacent to
      * PAVEMENT blocks. Managed by ClosingDownSaleSystem.
      */
-    CLOSING_DOWN_SHOP;
+    CLOSING_DOWN_SHOP,
+
+    // ── Issue #1481: Northfield Driving Test Centre ───────────────────────────
+
+    /**
+     * DRIVING_TEST_CENTRE — the Northfield DVSA Driving Test Centre on the
+     * industrial estate. A squat 1970s beige pebble-dash building.
+     * Open Mon–Fri 09:00–17:00.
+     * Staffed by Sandra (TEST_CENTRE_RECEPTIONIST) at the reception desk and
+     * Keith (DRIVING_EXAMINER) as test examiner. Wayne (TEST_SLOT_SCALPER)
+     * loiters outside. Managed by DrivingTestSystem.
+     */
+    DRIVING_TEST_CENTRE;
 
     /**
      * Returns the display name shown on the building's sign.
@@ -914,6 +926,7 @@ public enum LandmarkType {
             case BALTI_HOUSE:           return "The Raj Mahal";
             case RECORD_SHOP:           return "Spin City Records";
             case CLOSING_DOWN_SHOP:     return "Dave's Electronics & Electrical — FINAL WEEK";
+            case DRIVING_TEST_CENTRE:   return "Northfield DVSA Driving Test Centre";
             default:                    return null; // No sign for parks, houses, etc.
         }
     }

--- a/src/main/java/ragamuffin/world/PropType.java
+++ b/src/main/java/ragamuffin/world/PropType.java
@@ -4417,7 +4417,41 @@ public enum PropType {
      * Causes NeighbourhoodSystem Vibes −3/day while present.
      * Show to Gary (ClaimsManagementSystem) for a 12 COIN emotional distress payout.
      */
-    NOTICE_OF_DEFICIENCY_PROP(0.40f, 0.60f, 0.05f, 2, null);
+    NOTICE_OF_DEFICIENCY_PROP(0.40f, 0.60f, 0.05f, 2, null),
+
+    // ── Issue #1481: Northfield Driving Test Centre ───────────────────────────
+
+    /**
+     * TEST_CENTRE_DESK_PROP — the DVSA reception counter staffed by Sandra
+     * (TEST_CENTRE_RECEPTIONIST). Press E to book a test (5 COIN) or cancel.
+     * Collision: 1.20w × 1.00h × 0.60d. Health: 8 hits. Drops nothing.
+     */
+    TEST_CENTRE_DESK_PROP(1.20f, 1.00f, 0.60f, 8, null),
+
+    /**
+     * TEST_CAR_PROP — the DVSA test vehicle used during the practical examination.
+     * Keith (DRIVING_EXAMINER) boards this for the 8-step BattleBarMiniGame route.
+     * Located in the test centre car park. Collision: 2.00w × 1.20h × 4.00d.
+     * Health: 20 hits. Drops nothing (government property).
+     */
+    TEST_CAR_PROP(2.00f, 1.20f, 4.00f, 20, null),
+
+    /**
+     * TEST_CENTRE_REAR_EXIT_PROP — the rear fire-door exit of the Driving Test Centre.
+     * Keith (DRIVING_EXAMINER) lingers here 17:00–17:30 after a player test failure.
+     * Press E with BROWN_ENVELOPE (≥ 12 COIN) to attempt a bribe.
+     * Collision: 1.00w × 2.00h × 0.20d. Health: 6 hits. Drops nothing.
+     */
+    TEST_CENTRE_REAR_EXIT_PROP(1.00f, 2.00f, 0.20f, 6, null),
+
+    /**
+     * TEST_CENTRE_PHONE_BOX_PROP — a BT phone box adjacent to the Driving Test Centre.
+     * Press E to make an anonymous tip to the DVSA inspector, seeding
+     * BENT_EXAMINER_RUMOUR and triggering the inspector's visit next morning at 09:30.
+     * Achievement: INSPECTOR_CALLED.
+     * Collision: 0.90w × 2.20h × 0.90d. Health: 4 hits. Drops nothing.
+     */
+    TEST_CENTRE_PHONE_BOX_PROP(0.90f, 2.20f, 0.90f, 4, null);
 
     // ─────────────────────────────────────────────────────────────────────────
     // Issue #719: Collision and destructibility data


### PR DESCRIPTION
## Summary
Automated fix for issue #1481.

## Changes
- Fix #1481: automated fix

Closes #1481