### PR TITLE
Fix #1497: Add Northfield Angling Club — Ron's Sunday Match, the Dodgy Scales & the Keepnet Heist

### DIFF
--- a/src/main/java/ragamuffin/building/Material.java
+++ b/src/main/java/ragamuffin/building/Material.java
@@ -7279,7 +7279,53 @@ public enum Material {
      * also kept in the back office trophy cabinet. Fenceable for 20 COIN or
      * pawnable for 12 COIN.
      */
-    REGIONAL_CHAMPION_SHIELD_PROP("Regional Champion Shield");
+    REGIONAL_CHAMPION_SHIELD_PROP("Regional Champion Shield"),
+
+    // ── Issue #1497: Northfield Angling Club ──────────────────────────────────
+
+    /**
+     * MATCH_DAY_CARD — issued by Ron Birch (ANGLING_CLUB_CHAIR) on paying the
+     * 3 COIN entry fee for the Sunday match. Required to fish the match water
+     * without triggering a MATCH_POACHING warning. Expires at 10:00 on match day.
+     * Tooltip: "Northfield Angling Club — Sunday Match Card. Keep it on you, Ron checks."
+     */
+    MATCH_DAY_CARD("Match Day Card"),
+
+    /**
+     * KEEPNET — collects CANAL_FISH caught during the angling match.
+     * Fish placed in the keepnet contribute to the player's weigh-in total.
+     * Each fish is randomly seeded 120–800g by AnglingClubSystem.
+     * The keepnet can be stuffed with BRICK or SCRAP_METAL (+350g each) before
+     * the weigh-in, but Ron has a 25% chance of inspecting.
+     * Tooltip: "Green mesh keepnet. Goes in the water. Fish go in it. Simple as."
+     */
+    KEEPNET("Keepnet"),
+
+    /**
+     * GRUDGING_THANKS_TOKEN — given by Ron Birch when the player returns the
+     * ANGLING_TROPHY_PROP after stealing it. Unlocks AchievementType.RETURNED_THE_TROPHY
+     * and grants Vibes +2. No resale value.
+     * Tooltip: "A handwritten note from Ron. 'Cheers. Don't do it again.'"
+     */
+    GRUDGING_THANKS_TOKEN("Grudging Thanks Token"),
+
+    /**
+     * ANGLING_TROPHY_PROP — the Northfield Angling Club Sunday Match trophy.
+     * Awarded to the winner at 10:00 weigh-in (AchievementType.CANAL_CHAMPION).
+     * Also stored in Ron's TRANSIT_VAN_PROP during the match as spare.
+     * Fenceable for 12 COIN, pawnable for 8 COIN.
+     * Returnable to Ron for AchievementType.RETURNED_THE_TROPHY + Vibes +2.
+     * Tooltip: "A small brass trophy. 'Northfield Angling Club — Sunday Champion.'"
+     */
+    ANGLING_TROPHY_PROP("Angling Trophy"),
+
+    /**
+     * CASHBOX_PROP — Ron's entry-fee cashbox kept in the TRANSIT_VAN_PROP boot.
+     * Contains 24–27 COIN pooled from entry fees (varies with registrant count).
+     * Can be stolen as part of the Keepnet Heist mechanic.
+     * Tooltip: "A dented metal cashbox. Probably holds the match entry money."
+     */
+    CASHBOX_PROP("Cashbox");
 
     private final String displayName;
 
@@ -8806,6 +8852,18 @@ public enum Material {
                                                     0.12f, 0.22f, 0.68f); // Blue official stamp
             case HOMEMADE_CAKE_SLICE:     return cs(0.95f, 0.90f, 0.80f, // Cream sponge
                                                     0.85f, 0.32f, 0.32f); // Pink jam layer
+
+            // Issue #1497: Northfield Angling Club
+            case MATCH_DAY_CARD:          return cs(0.10f, 0.55f, 0.25f, // Club green card
+                                                    0.92f, 0.92f, 0.88f); // White text area
+            case KEEPNET:                 return cs(0.12f, 0.38f, 0.18f, // Dark green mesh
+                                                    0.05f, 0.22f, 0.10f); // Deeper net shadow
+            case GRUDGING_THANKS_TOKEN:   return cs(0.92f, 0.92f, 0.88f, // White paper note
+                                                    0.45f, 0.38f, 0.28f); // Brown biro scrawl
+            case ANGLING_TROPHY_PROP:     return cs(0.88f, 0.72f, 0.22f, // Brass trophy
+                                                    0.70f, 0.55f, 0.12f); // Darker brass base
+            case CASHBOX_PROP:            return cs(0.42f, 0.42f, 0.45f, // Dented grey metal
+                                                    0.25f, 0.25f, 0.28f); // Dark shadow
 
             default:             return c(0.5f, 0.5f, 0.5f);
         }
@@ -11248,6 +11306,18 @@ public enum Material {
                 return IconShape.FLAT_PAPER;  // official-looking form
             case HOMEMADE_CAKE_SLICE:
                 return IconShape.FOOD;        // slice of Victoria sponge
+
+            // Issue #1497: Northfield Angling Club
+            case MATCH_DAY_CARD:
+                return IconShape.FLAT_PAPER;  // laminated match card
+            case KEEPNET:
+                return IconShape.BOX;         // mesh net bundle
+            case GRUDGING_THANKS_TOKEN:
+                return IconShape.FLAT_PAPER;  // handwritten note
+            case ANGLING_TROPHY_PROP:
+                return IconShape.CYLINDER;    // brass trophy
+            case CASHBOX_PROP:
+                return IconShape.BOX;         // metal cashbox
 
             default:
                 return IconShape.BOX;

--- a/src/main/java/ragamuffin/core/CriminalRecord.java
+++ b/src/main/java/ragamuffin/core/CriminalRecord.java
@@ -1402,7 +1402,24 @@ public class CriminalRecord {
          * Requires evidence of 2+ grading fees collected. Gary pays once then
          * becomes permanently hostile. RumourType.CLUB_SNITCH seeded (Vibes −2).
          */
-        BLACKMAIL("Blackmail (karate club grading scam)");
+        BLACKMAIL("Blackmail (karate club grading scam)"),
+
+        // ── Issue #1497: Northfield Angling Club ─────────────────────────────
+
+        /**
+         * CHEATING_AT_ANGLING — recorded when Ron detects the player wedging the
+         * WEIGH_SCALES_PROP (20% detection chance) or stuffing the KEEPNET_PROP with
+         * non-fish items (25% detection chance). Results in 14-day ban and
+         * Notoriety +4 (scales) or +5 (stuffed net). RumourType.DODGY_ANGLER seeded.
+         */
+        CHEATING_AT_ANGLING("Cheating at angling (match weight tampering)"),
+
+        /**
+         * MATCH_POACHING — recorded when a PCSO is called after the player's second
+         * poaching violation (fishing match water without MATCH_DAY_CARD, witnessed
+         * by a MATCH_ANGLER within 10 blocks). First violation is a verbal warning.
+         */
+        MATCH_POACHING("Poaching (fishing match water without a match day card)");
 
         private final String displayName;
 

--- a/src/main/java/ragamuffin/core/RumourType.java
+++ b/src/main/java/ragamuffin/core/RumourType.java
@@ -1854,5 +1854,31 @@ public enum RumourType {
      * — seeded by KarateSystem when the player returns the stolen trophy to Gary
      * (AchievementType.HONOURABLE_THIEF). Spreads via PUBLIC and KARATE_KID NPCs.
      * Vibes +3. */
-    HONOURABLE_THIEF;
+    HONOURABLE_THIEF,
+
+    // ── Issue #1497: Northfield Angling Club ──────────────────────────────────
+
+    /** "Someone wedged the scales at the angling match. Ron weighed their catch
+     * and it was bang on 400g too heavy — absolute shambles."
+     * — seeded by AnglingClubSystem when CHEATING_AT_ANGLING is detected post-match.
+     * Spreads via MATCH_ANGLER and PUBLIC NPCs. Vibes −2. */
+    DODGY_ANGLER,
+
+    /** "Heard someone had it away with Ron's van — nicked the trophy and the
+     * match money right out the boot. Broad daylight too."
+     * — seeded by AnglingClubSystem when the van boot is raided (KEEPNET_RAIDER)
+     * or burglary is witnessed. Spreads via MATCH_ANGLER and PUBLIC NPCs. Vibes −3. */
+    VAN_THIEF,
+
+    /** "Apparently the lad who nicked Ron's trophy brought it back.
+     * Ron shook his hand, which is more than I'd have done."
+     * — seeded by AnglingClubSystem when RETURNED_THE_TROPHY is awarded.
+     * Spreads via MATCH_ANGLER and PUBLIC NPCs. Vibes +2. */
+    REPENTANT_THIEF,
+
+    /** "Someone absolutely smashed the angling match this Sunday —
+     * biggest haul Ron's seen in years. He was gutted to hand the trophy over."
+     * — seeded by AnglingClubSystem when CANAL_CHAMPION is awarded to the player.
+     * Spreads via MATCH_ANGLER and PUBLIC NPCs. Vibes +1. */
+    CANAL_CHAMPION;
 }

--- a/src/main/java/ragamuffin/entity/NPCType.java
+++ b/src/main/java/ragamuffin/entity/NPCType.java
@@ -3494,7 +3494,26 @@ public enum NPCType {
      * Annual Tournament. Accept 1–10 COIN wagers on the Grudge Match (1.5× payout).
      * Spread BOWLS_GRUDGE_MATCH rumours after the match concludes.
      */
-    BOWLS_SPECTATOR(20f, 0f, 0f, false);
+    BOWLS_SPECTATOR(20f, 0f, 0f, false),
+
+    // ── Issue #1497: Northfield Angling Club ──────────────────────────────────
+
+    /**
+     * ANGLING_CLUB_CHAIR — Ron Birch, chairman of the Northfield Angling Club.
+     * Runs the fortnightly Sunday match at LandmarkType.CANAL (07:00–10:00).
+     * Manages peg allocation, weighs catches at 10:00, and awards the trophy.
+     * Has a 20% chance of detecting dodgy scales post-match and 25% chance of
+     * inspecting stuffed keepnets. Passive outside match hours.
+     */
+    ANGLING_CLUB_CHAIR(25f, 0f, 0f, false),
+
+    /**
+     * MATCH_ANGLER — competitive angler taking a numbered peg during a Sunday
+     * match. Witnesses poaching within 10 blocks (issues verbal warning on first
+     * violation, calls PCSO on second). NPC catch rate reduced to 40% on prime
+     * pegs taken by the player via early arrival.
+     */
+    MATCH_ANGLER(20f, 0f, 0f, false);
 
     private final float maxHealth;
     private final float attackDamage;   // Damage per hit to player

--- a/src/main/java/ragamuffin/world/PropType.java
+++ b/src/main/java/ragamuffin/world/PropType.java
@@ -4582,7 +4582,72 @@ public enum PropType {
      * displayed in the back office. Fenceable for 20 COIN or pawnable for 12 COIN.
      * Collision: 0.30w × 0.50h × 0.10d. Health: 2 hits. Drops REGIONAL_CHAMPION_SHIELD_PROP material.
      */
-    REGIONAL_CHAMPION_SHIELD_PROP(0.30f, 0.50f, 0.10f, 2, Material.REGIONAL_CHAMPION_SHIELD_PROP);
+    REGIONAL_CHAMPION_SHIELD_PROP(0.30f, 0.50f, 0.10f, 2, Material.REGIONAL_CHAMPION_SHIELD_PROP),
+
+    // ── Issue #1497: Northfield Angling Club ──────────────────────────────────
+
+    /**
+     * PEBBLE_PEG_PROP — a numbered peg marker placed along the towpath at the start of
+     * the Sunday match. Each angler occupies one peg; player takes a peg on registration.
+     * Collision: 0.10w × 0.30h × 0.10d. Health: 2 hits. No drop.
+     */
+    PEBBLE_PEG_PROP(0.10f, 0.30f, 0.10f, 2, null),
+
+    /**
+     * WEIGH_TABLE_PROP — the folding table Ron uses to weigh catches at 10:00.
+     * Present during the match (07:00–10:00). Interaction shows current standings.
+     * Collision: 1.50w × 0.80h × 0.60d. Health: 5 hits. Drops WOOD.
+     */
+    WEIGH_TABLE_PROP(1.50f, 0.80f, 0.60f, 5, Material.WOOD),
+
+    /**
+     * WEIGH_SCALES_PROP — the portable spring balance scales on the weigh table.
+     * Player can wedge with 2 COIN (TAMPER_WITNESS_RANGE = 4.0f) to add
+     * SCALES_BIAS_GRAMS = 400g to their announced catch weight.
+     * Collision: 0.30w × 0.25h × 0.30d. Health: 3 hits. Drops SCRAP_METAL.
+     */
+    WEIGH_SCALES_PROP(0.30f, 0.25f, 0.30f, 3, Material.SCRAP_METAL),
+
+    /**
+     * RESULTS_BOARD_PROP — a whiteboard posted after the weigh-in showing the
+     * final standings. Readable via E interaction. Collision: 0.80w × 1.20h × 0.10d.
+     * Health: 4 hits. Drops WOOD.
+     */
+    RESULTS_BOARD_PROP(0.80f, 1.20f, 0.10f, 4, Material.WOOD),
+
+    /**
+     * TRANSIT_VAN_PROP — Ron Birch's white Transit van parked near the canal
+     * during the Sunday match (07:00–10:00). Boot holds ANGLING_TROPHY_PROP
+     * and CASHBOX_PROP (24–27 COIN). Boot opened with LOCKPICK (silent) or
+     * 4 CROWBAR hits (loud). Collision: 2.20w × 1.80h × 4.50d. Health: 20 hits.
+     * Drops SCRAP_METAL.
+     */
+    TRANSIT_VAN_PROP(2.20f, 1.80f, 4.50f, 20, Material.SCRAP_METAL),
+
+    /**
+     * VAN_BOOT_PROP — the boot compartment of Ron's Transit van.
+     * Contains ANGLING_TROPHY_PROP and CASHBOX_PROP during the match.
+     * Opened silently with LOCKPICK or noisily with 4 CROWBAR hits.
+     * Collision: 1.80w × 0.80h × 0.60d. Health: 4 hits. No drop.
+     */
+    VAN_BOOT_PROP(1.80f, 0.80f, 0.60f, 4, null),
+
+    /**
+     * KEEPNET_PROP — mesh keepnet staked in the water at the player's peg.
+     * Caught CANAL_FISH are placed here automatically during the match.
+     * Fish weight is seeded 120–800g each. Can be stuffed with BRICK or SCRAP_METAL
+     * for extra weight (+350g each item). Collision: 0.40w × 0.20h × 0.80d. Health: 2 hits.
+     * Drops KEEPNET material.
+     */
+    KEEPNET_PROP(0.40f, 0.20f, 0.80f, 2, Material.KEEPNET),
+
+    /**
+     * ANGLING_TROPHY_PROP — the Sunday match trophy stored in the van boot.
+     * Awarded to the weigh-in winner at 10:00. Fenceable for 12 COIN, pawnable
+     * for 8 COIN. Returnable to Ron for AchievementType.RETURNED_THE_TROPHY.
+     * Collision: 0.20w × 0.35h × 0.20d. Health: 2 hits. Drops ANGLING_TROPHY_PROP material.
+     */
+    ANGLING_TROPHY_PROP(0.20f, 0.35f, 0.20f, 2, Material.ANGLING_TROPHY_PROP);
 
     // ─────────────────────────────────────────────────────────────────────────
     // Issue #719: Collision and destructibility data


### PR DESCRIPTION
## Summary
Automated fix for issue #1497.

## Changes
- Fix #1497: automated fix

Closes #1497