### PR TITLE
Fix #1499: Add Northfield Model Railway Club — Derek's Layout, the Charity Raffle Scam & the Signal Box Heist

### DIFF
--- a/src/main/java/ragamuffin/building/Material.java
+++ b/src/main/java/ragamuffin/building/Material.java
@@ -7325,7 +7325,49 @@ public enum Material {
      * Can be stolen as part of the Keepnet Heist mechanic.
      * Tooltip: "A dented metal cashbox. Probably holds the match entry money."
      */
-    CASHBOX_PROP("Cashbox");
+    CASHBOX_PROP("Cashbox"),
+
+    // ── Issue #1499: Northfield Model Railway Club ────────────────────────────
+
+    /**
+     * SIGNAL_BOX_DIORAMA_PROP — Derek's hand-built signal box diorama; the star
+     * prize in the Model Railway Club raffle. Three years in the making.
+     * Fenceable for 20 COIN (DIORAMA_FENCE_VALUE), pawnable for 14 COIN
+     * (DIORAMA_PAWN_VALUE). Also dropped by PropType.SIGNAL_BOX_DIORAMA_PROP when
+     * picked up via E interaction (hitsToBreak = 0).
+     * Tooltip: "A detailed hand-built signal box diorama. Derek spent three years on this."
+     */
+    SIGNAL_BOX_DIORAMA_PROP("Signal Box Diorama"),
+
+    /**
+     * LOCO_MODEL_PROP — 2nd prize in the Model Railway Club raffle; a detailed
+     * locomotive model. Fenceable for 8 COIN, pawnable for 5 COIN.
+     * Tooltip: "A finely detailed locomotive model. OO gauge, of course."
+     */
+    LOCO_MODEL_PROP("Loco Model"),
+
+    /**
+     * TRACK_PACK_PROP — 3rd prize in the Model Railway Club raffle; a pack of
+     * model railway track sections. Fenceable for 3 COIN, pawnable for 2 COIN.
+     * Tooltip: "A pack of model railway track sections. Sealed."
+     */
+    TRACK_PACK_PROP("Track Pack"),
+
+    /**
+     * RAFFLE_CONSOLATION_VOUCHER — "Better luck next time" printed slip awarded
+     * to non-prize raffle draws. Worth 0 COIN.
+     * Tooltip: "Better luck next time. Thanks for supporting the club."
+     */
+    RAFFLE_CONSOLATION_VOUCHER("Consolation Voucher"),
+
+    /**
+     * CLUB_MEMBERSHIP_TOKEN — lifetime membership token issued by Derek when the
+     * stolen diorama is voluntarily returned (AchievementType.DECENT_SORT).
+     * Grants IS_MEMBER flag on player; prevents TRESPASS charge on Tuesday club
+     * nights. Worth 0 COIN but prevents future trespass charges.
+     * Tooltip: "Northfield Model Railway Club life membership. Derek's handwriting."
+     */
+    CLUB_MEMBERSHIP_TOKEN("Club Membership Token");
 
     private final String displayName;
 
@@ -8864,6 +8906,18 @@ public enum Material {
                                                     0.70f, 0.55f, 0.12f); // Darker brass base
             case CASHBOX_PROP:            return cs(0.42f, 0.42f, 0.45f, // Dented grey metal
                                                     0.25f, 0.25f, 0.28f); // Dark shadow
+
+            // Issue #1499: Northfield Model Railway Club
+            case SIGNAL_BOX_DIORAMA_PROP: return cs(0.68f, 0.42f, 0.18f, // Warm timber brown
+                                                    0.22f, 0.42f, 0.22f); // Green roof detail
+            case LOCO_MODEL_PROP:         return cs(0.18f, 0.18f, 0.20f, // Dark engine black
+                                                    0.72f, 0.20f, 0.12f); // Red buffer highlight
+            case TRACK_PACK_PROP:         return cs(0.40f, 0.40f, 0.42f, // Grey metal rail
+                                                    0.55f, 0.42f, 0.28f); // Brown sleeper
+            case RAFFLE_CONSOLATION_VOUCHER: return cs(0.92f, 0.92f, 0.88f, // White paper
+                                                    0.68f, 0.22f, 0.18f); // Red printed text
+            case CLUB_MEMBERSHIP_TOKEN:   return cs(0.10f, 0.25f, 0.55f, // Club navy blue
+                                                    0.92f, 0.92f, 0.88f); // White text area
 
             default:             return c(0.5f, 0.5f, 0.5f);
         }
@@ -11318,6 +11372,18 @@ public enum Material {
                 return IconShape.CYLINDER;    // brass trophy
             case CASHBOX_PROP:
                 return IconShape.BOX;         // metal cashbox
+
+            // Issue #1499: Northfield Model Railway Club
+            case SIGNAL_BOX_DIORAMA_PROP:
+                return IconShape.BOX;         // detailed diorama model
+            case LOCO_MODEL_PROP:
+                return IconShape.BOX;         // locomotive model
+            case TRACK_PACK_PROP:
+                return IconShape.FLAT_PAPER;  // sealed track pack
+            case RAFFLE_CONSOLATION_VOUCHER:
+                return IconShape.FLAT_PAPER;  // printed consolation slip
+            case CLUB_MEMBERSHIP_TOKEN:
+                return IconShape.FLAT_PAPER;  // laminated membership token
 
             default:
                 return IconShape.BOX;

--- a/src/main/java/ragamuffin/core/RumourType.java
+++ b/src/main/java/ragamuffin/core/RumourType.java
@@ -1880,5 +1880,31 @@ public enum RumourType {
      * biggest haul Ron's seen in years. He was gutted to hand the trophy over."
      * — seeded by AnglingClubSystem when CANAL_CHAMPION is awarded to the player.
      * Spreads via MATCH_ANGLER and PUBLIC NPCs. Vibes +1. */
-    CANAL_CHAMPION;
+    CANAL_CHAMPION,
+
+    // ── Issue #1499: Northfield Model Railway Club ────────────────────────────
+
+    /** "Someone got caught fiddling the barrel at the Model Railway Club raffle.
+     * Derek threw them out. Three years he spent on that signal box."
+     * — seeded by ModelRailwaySystem when RAFFLE_FRAUD is witnessed.
+     * Spreads via RAILWAY_MEMBER and PUBLIC NPCs. Vibes −3. */
+    RAFFLE_CHEAT,
+
+    /** "The signal box diorama's gone from the model railway club.
+     * Derek's absolutely devastated. Took him three years, that."
+     * — seeded by ModelRailwaySystem when diorama theft is witnessed or discovered.
+     * Spreads via RAILWAY_MEMBER and PUBLIC NPCs. Vibes −2. */
+    DIORAMA_NICKED,
+
+    /** "Some lad brought Derek's signal box back. Derek shook his hand and gave
+     * him a life membership. Didn't ask any questions."
+     * — seeded by ModelRailwaySystem when DECENT_SORT is awarded (diorama returned).
+     * Spreads via RAILWAY_MEMBER and PUBLIC NPCs. Vibes +2. */
+    DIORAMA_RETURNED,
+
+    /** "Player won the signal box diorama at the model railway raffle.
+     * Derek looked sick as a dog."
+     * — seeded by ModelRailwaySystem on legitimate raffle win (LUCKY_DIP).
+     * Spreads on legitimate raffle win. Vibes +1. */
+    RAFFLE_WINNER;
 }

--- a/src/main/java/ragamuffin/entity/NPCType.java
+++ b/src/main/java/ragamuffin/entity/NPCType.java
@@ -3513,7 +3513,32 @@ public enum NPCType {
      * violation, calls PCSO on second). NPC catch rate reduced to 40% on prime
      * pegs taken by the player via early arrival.
      */
-    MATCH_ANGLER(20f, 0f, 0f, false);
+    MATCH_ANGLER(20f, 0f, 0f, false),
+
+    // ── Issue #1499: Northfield Model Railway Club ────────────────────────────
+
+    /**
+     * MODEL_RAILWAY_CHAIR — Derek Hodges, chairman of the Northfield Model Railway Club.
+     * Presides over the public open day layout (every 3rd Saturday, 10:00–16:00)
+     * and conducts the raffle draw at 15:30. Passive during LAYOUT_DERAILMENT_EVENT
+     * (faces the layout). Becomes hostile if diorama theft is witnessed.
+     */
+    MODEL_RAILWAY_CHAIR(25f, 0f, 0f, false),
+
+    /**
+     * RAFFLE_VOLUNTEER — Pauline, raffle ticket seller.
+     * Stationed at the door on open days. Sells RAFFLE_TICKET items (max 3 per player).
+     * Witnesses barrel tampering within BARREL_WITNESS_RANGE (4.0f blocks).
+     */
+    RAFFLE_VOLUNTEER(20f, 0f, 0f, false),
+
+    /**
+     * RAILWAY_MEMBER — a Northfield Model Railway Club member.
+     * 4–6 spawn on open days; gather around the layout during LAYOUT_DERAILMENT_EVENT.
+     * Witness diorama theft at WITNESS_RANGE_NORMAL (reduced to WITNESS_RANGE_DERAILMENT
+     * during derailment).
+     */
+    RAILWAY_MEMBER(20f, 0f, 0f, false);
 
     private final float maxHealth;
     private final float attackDamage;   // Damage per hit to player

--- a/src/main/java/ragamuffin/world/PropType.java
+++ b/src/main/java/ragamuffin/world/PropType.java
@@ -4647,7 +4647,38 @@ public enum PropType {
      * for 8 COIN. Returnable to Ron for AchievementType.RETURNED_THE_TROPHY.
      * Collision: 0.20w × 0.35h × 0.20d. Health: 2 hits. Drops ANGLING_TROPHY_PROP material.
      */
-    ANGLING_TROPHY_PROP(0.20f, 0.35f, 0.20f, 2, Material.ANGLING_TROPHY_PROP);
+    ANGLING_TROPHY_PROP(0.20f, 0.35f, 0.20f, 2, Material.ANGLING_TROPHY_PROP),
+
+    // ── Issue #1499: Northfield Model Railway Club ────────────────────────────
+
+    /**
+     * RAFFLE_BARREL_PROP — a wooden tombola barrel on a stand near the Community
+     * Centre door. Press E to interact (buy tickets or swap barrel).
+     * Collision: 1.0w × 1.0h × 1.0d. Not breakable (hitsToBreak = 0).
+     */
+    RAFFLE_BARREL_PROP(1.0f, 1.0f, 1.0f, 0, null),
+
+    /**
+     * DISPLAY_TABLE_PROP — long trestle table holding Derek's model railway layout.
+     * Blocks access to the layout area. Not breakable.
+     * Collision: 3.0w × 0.8h × 1.0d.
+     */
+    DISPLAY_TABLE_PROP(3.0f, 0.8f, 1.0f, 0, null),
+
+    /**
+     * SIGNAL_BOX_DIORAMA_PROP — Derek's hand-built signal box diorama on the
+     * DISPLAY_TABLE_PROP. Press E to pick up (hitsToBreak = 0, not breakable —
+     * E interaction only). Drops Material.SIGNAL_BOX_DIORAMA_PROP.
+     * Collision: 0.8w × 0.6h × 0.5d.
+     */
+    SIGNAL_BOX_DIORAMA_PROP(0.8f, 0.6f, 0.5f, 0, Material.SIGNAL_BOX_DIORAMA_PROP),
+
+    /**
+     * LOCO_DISPLAY_PROP — a display case of model locomotives in the Community
+     * Centre hall. Decorative; press E to view. No item drop.
+     * Collision: 1.2w × 1.5h × 0.4d.
+     */
+    LOCO_DISPLAY_PROP(1.2f, 1.5f, 0.4f, 0, null);
 
     // ─────────────────────────────────────────────────────────────────────────
     // Issue #719: Collision and destructibility data


### PR DESCRIPTION
## Summary
Automated fix for issue #1499.

## Changes
- Fix #1499: automated fix

Closes #1499